### PR TITLE
Add clean subcommand and a few other things

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,0 @@
-go build -ldflags '-X main.version=2.7.1@1'

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,5 @@
-if (-not gc googet.goospec | where {$_ -match '"version": "(.+)",'}) {
-  throw 'Error grabbing version from goospec"
+if (!(gc googet.goospec | where {$_ -match '"version": "(.+)",'})) {
+  throw 'Error grabbing version from goospec'
 }
 $version = $matches[1]
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,6 @@
+if (-not gc googet.goospec | where {$_ -match '"version": "(.+)",'}) {
+  throw 'Error grabbing version from goospec"
+}
+$version = $matches[1]
+
+go build -ldflags "-X main.version=$version"

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,7 @@
 #! /bin/sh
-GOOS=windows go build -ldflags '-X main.version=2.7.1@1'
+version=$(cat googet.goospec | grep -Po '"version":\s+"\K.+(?=",)')
+if [[ $? -ne 0 ]]; then
+  echo "could not match verson in goospec"
+  exit 1
+fi
+GOOS=windows go build -ldflags "-X main.version=2.7.1@1"

--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,4 @@ if [[ $? -ne 0 ]]; then
   echo "could not match verson in goospec"
   exit 1
 fi
-GOOS=windows go build -ldflags "-X main.version=2.7.1@1"
+GOOS=windows go build -ldflags "-X main.version=${version}"

--- a/googet.go
+++ b/googet.go
@@ -1,5 +1,4 @@
 /*
-
 Copyright 2016 Google Inc. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/googet.go
+++ b/googet.go
@@ -1,4 +1,5 @@
 /*
+
 Copyright 2016 Google Inc. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -320,6 +321,7 @@ func run() int {
 	cmdr.Register(&installedCmd{}, "package query")
 	cmdr.Register(&latestCmd{}, "package query")
 	cmdr.Register(&availableCmd{}, "package query")
+	cmdr.Register(&cleanCmd{}, "")
 
 	cmdr.ImportantFlag("verbose")
 	cmdr.ImportantFlag("noconfirm")

--- a/googet.goospec
+++ b/googet.goospec
@@ -1,6 +1,6 @@
 {
   "name": "googet",
-  "version": "2.7.1@1",
+  "version": "2.8.0@1",
   "arch": "x86_64",
   "authors": "ajackura",
   "owners": "ajackura",
@@ -12,6 +12,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.8.0 - Add clean command for cleaning cache directory.",
     "2.7.1 - Add option for multiple repository entries.",
     "2.7.0 - Support for extended-length paths on Windows.",
     "2.6.1 - Remove some old code.",

--- a/googet_available.go
+++ b/googet_available.go
@@ -39,7 +39,7 @@ type availableCmd struct {
 }
 
 func (*availableCmd) Name() string     { return "available" }
-func (*availableCmd) Synopsis() string { return "List all available packages in repos." }
+func (*availableCmd) Synopsis() string { return "list all available packages in repos" }
 func (*availableCmd) Usage() string {
 	return fmt.Sprintf("%s available [-sources repo1,repo2...] [-filter <name>] [-info]\n", path.Base(os.Args[0]))
 }

--- a/googet_clean.go
+++ b/googet_clean.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/googet/goolib"
+	"github.com/google/logger"
+	"github.com/google/subcommands"
+	"golang.org/x/net/context"
+)
+
+type cleanCmd struct{}
+
+func (*cleanCmd) Name() string     { return "clean" }
+func (*cleanCmd) Synopsis() string { return "clean the cache directory" }
+func (*cleanCmd) Usage() string {
+	return fmt.Sprintf("%s clean\n", filepath.Base(os.Args[0]))
+}
+
+func (cmd *cleanCmd) SetFlags(f *flag.FlagSet) {}
+
+func (cmd *cleanCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	fmt.Println("Removing all files and directories in cachedir that dont correspond to a currently installed package.")
+	state, err := readState(filepath.Join(rootDir, stateFile))
+	if err != nil {
+		logger.Fatal(err)
+	}
+	var il []string
+	for _, pkg := range *state {
+		il = append(il, pkg.UnpackDir)
+	}
+	files, err := filepath.Glob(filepath.Join(rootDir, cacheDir, "*"))
+	if err != nil {
+		logger.Fatal(err)
+	}
+	for _, file := range files {
+		if !goolib.ContainsString(file, il) {
+			if err := os.RemoveAll(file); err != nil {
+				logger.Error(err)
+			}
+		}
+	}
+
+	return subcommands.ExitSuccess
+}

--- a/googet_download.go
+++ b/googet_download.go
@@ -35,7 +35,7 @@ type downloadCmd struct {
 }
 
 func (*downloadCmd) Name() string     { return "download" }
-func (*downloadCmd) Synopsis() string { return "Download a package." }
+func (*downloadCmd) Synopsis() string { return "download a package" }
 func (*downloadCmd) Usage() string {
 	return fmt.Sprintf("%s download [-sources repo1,repo2...] [-download_dir <dir>] <name>\n", filepath.Base(os.Args[0]))
 }

--- a/googet_install.go
+++ b/googet_install.go
@@ -38,7 +38,7 @@ type installCmd struct {
 }
 
 func (*installCmd) Name() string     { return "install" }
-func (*installCmd) Synopsis() string { return "Download and install a package and its dependencies." }
+func (*installCmd) Synopsis() string { return "download and install a package and its dependencies" }
 func (*installCmd) Usage() string {
 	return fmt.Sprintf("%s install [-reinstall] [-source repo1,repo2...] <name>\n", filepath.Base(os.Args[0]))
 }

--- a/googet_installed.go
+++ b/googet_installed.go
@@ -38,7 +38,7 @@ type installedCmd struct {
 }
 
 func (*installedCmd) Name() string     { return "installed" }
-func (*installedCmd) Synopsis() string { return "List all installed packages." }
+func (*installedCmd) Synopsis() string { return "list all installed packages" }
 func (*installedCmd) Usage() string {
 	return fmt.Sprintf("%s installed [-filter <name>] [-info]\n", path.Base(os.Args[0]))
 }

--- a/googet_latest.go
+++ b/googet_latest.go
@@ -34,7 +34,7 @@ type latestCmd struct {
 }
 
 func (*latestCmd) Name() string     { return "latest" }
-func (*latestCmd) Synopsis() string { return "Get the latest available version of a package." }
+func (*latestCmd) Synopsis() string { return "get the latest available version of a package" }
 func (*latestCmd) Usage() string {
 	return fmt.Sprintf("%s latest [-sources repo1,repo2...] [-compare] <name>\n", filepath.Base(os.Args[0]))
 }

--- a/googet_remove.go
+++ b/googet_remove.go
@@ -34,7 +34,7 @@ type removeCmd struct {
 }
 
 func (cmd *removeCmd) Name() string     { return "remove" }
-func (cmd *removeCmd) Synopsis() string { return "Uninstall a package." }
+func (cmd *removeCmd) Synopsis() string { return "uninstall a package" }
 func (cmd *removeCmd) Usage() string {
 	return fmt.Sprintf("%s remove <name>", os.Args[0])
 }

--- a/googet_update.go
+++ b/googet_update.go
@@ -35,7 +35,7 @@ type updateCmd struct {
 }
 
 func (*updateCmd) Name() string     { return "update" }
-func (*updateCmd) Synopsis() string { return "Update all packages to the latest version available." }
+func (*updateCmd) Synopsis() string { return "update all packages to the latest version available" }
 func (*updateCmd) Usage() string {
 	return fmt.Sprintf("%s update [-sources repo1,repo2...]\n", filepath.Base(os.Args[0]))
 }

--- a/goopack/goopack.go
+++ b/goopack/goopack.go
@@ -228,7 +228,7 @@ func writeFiles(tw *tar.Writer, fm fileMap) error {
 			if err != nil {
 				return err
 			}
-			fih.Name = fpath
+			fih.Name = filepath.ToSlash(fpath)
 			if err := tw.WriteHeader(fih); err != nil {
 				return err
 			}


### PR DESCRIPTION
The clean subcommand removes all files and folders in the cache directory that don't correspond with a currently installed package.

Build script on windows is now PowerShell
Both windows and Linux build scripts pull version out of goospec file.