### PR TITLE
Update oswrap_windows.go

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -27,8 +27,8 @@ import (
 	"time"
 
 	"github.com/google/googet/goolib"
-	"github.com/google/logger"
 	"github.com/google/googet/oswrap"
+	"github.com/google/logger"
 )
 
 const (

--- a/download/download.go
+++ b/download/download.go
@@ -30,8 +30,8 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/google/googet/client"
 	"github.com/google/googet/goolib"
-	"github.com/google/logger"
 	"github.com/google/googet/oswrap"
+	"github.com/google/logger"
 )
 
 // Package downloads a package from the given url,

--- a/download/download_test.go
+++ b/download/download_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 
 	"github.com/google/googet/goolib"
-	"github.com/google/logger"
 	"github.com/google/googet/oswrap"
+	"github.com/google/logger"
 )
 
 func init() {

--- a/install/install.go
+++ b/install/install.go
@@ -27,9 +27,9 @@ import (
 	"github.com/google/googet/client"
 	"github.com/google/googet/download"
 	"github.com/google/googet/goolib"
+	"github.com/google/googet/oswrap"
 	"github.com/google/googet/system"
 	"github.com/google/logger"
-	"github.com/google/googet/oswrap"
 )
 
 // minInstalled reports whether the package is installed at the given version or greater.

--- a/install/install_test.go
+++ b/install/install_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/google/googet/client"
 	"github.com/google/googet/goolib"
-	"github.com/google/logger"
 	"github.com/google/googet/oswrap"
+	"github.com/google/logger"
 )
 
 func init() {
@@ -126,8 +126,7 @@ func TestInstallPkg(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	dst += (
-		"/this/is/an/extremely/long/filename/you/wouldnt/expect/to/see/it/" +
+	dst += ("/this/is/an/extremely/long/filename/you/wouldnt/expect/to/see/it/" +
 		"in/the/wild/but/you/would/actually/be/surprised/at/some/of/the/" +
 		"stuff/that/pops/up/and/seriously/two/hundred/and/fify/five/chars" +
 		"is/quite/a/large/number/but/somehow/there/were/real/goo/packages" +

--- a/oswrap/oswrap.go
+++ b/oswrap/oswrap.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package oswrap exists to translate pathnames into extended-length path names
+// behind the scenes, so that googet can install packages with deep directory
+// structures on Windows.
+package oswrap
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func rootDir(name string) string {
+	i := len(filepath.VolumeName(name))
+	if filepath.IsAbs(name) {
+		i++
+	}
+	for !os.IsPathSeparator(name[i]) {
+		i++
+	}
+	return name[:i]
+}
+
+func mkRootDir(name string, mode os.FileMode) error {
+	rd := rootDir(name)
+
+	if _, err := Stat(rd); err != nil {
+		if err := Mkdir(rd, mode); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/oswrap/oswrap_test.go
+++ b/oswrap/oswrap_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oswrap
+
+import (
+	"testing"
+)
+
+func TestRootDir(t *testing.T) {
+	var table = []struct {
+		path string
+		want string
+	}{
+		{"/some/abs/path", "/some"},
+		{"some/rel/path", "some"},
+	}
+	for _, tt := range table {
+		if got := rootDir(tt.path); got != tt.want {
+			t.Fatal("rootDir did not retunr expected path, got: %q, want: %q ", got, tt.want)
+		}
+	}
+}

--- a/oswrap/oswrap_unix.go
+++ b/oswrap/oswrap_unix.go
@@ -1,7 +1,18 @@
 //+build linux darwin
 
-// Package oswrap on unix only exists for api-compatibility with the windows
-// version. All functions are simply thin wrappers to the actual os functions.
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package oswrap
 
 import (

--- a/oswrap/oswrap_unix.go
+++ b/oswrap/oswrap_unix.go
@@ -5,8 +5,8 @@
 package oswrap
 
 import (
-	"path/filepath"
 	"os"
+	"path/filepath"
 )
 
 // Open calls os.Open

--- a/oswrap/oswrap_windows.go
+++ b/oswrap/oswrap_windows.go
@@ -1,8 +1,18 @@
 //+build windows
 
-// Package oswrap exists to translate pathnames into extended-length path names
-// behind the scenes, so that googet can install packages with deep directory
-// structures
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package oswrap
 
 import (
@@ -82,25 +92,17 @@ func Mkdir(name string, mode os.FileMode) error {
 
 // MkdirAll calls os.MkdirAll with name normalized
 func MkdirAll(name string, mode os.FileMode) error {
-	// os.MkdirAll does not work with extended-length paths if
-	// nothing in the path exists.
-	vol := filepath.VolumeName(name)
-	i := len(vol) + 1
-	for !os.IsPathSeparator(name[i]) {
-		i++
-	}
-	baseDir := name[:i]
-
-	if _, err := Stat(baseDir); err != nil {
-		if err := Mkdir(baseDir, mode); err != nil {
-			return err
-		}
-	}
-
 	name, err := normPath(name)
 	if err != nil {
 		return err
 	}
+
+	// os.MkdirAll does not work with extended-length paths if
+	// nothing in the path exists.
+	if err := mkRootDir(name, mode); err != nil {
+		return err
+	}
+
 	return os.MkdirAll(name, mode)
 }
 

--- a/oswrap/oswrap_windows.go
+++ b/oswrap/oswrap_windows.go
@@ -82,6 +82,21 @@ func Mkdir(name string, mode os.FileMode) error {
 
 // MkdirAll calls os.MkdirAll with name normalized
 func MkdirAll(name string, mode os.FileMode) error {
+	// os.MkdirAll does not work with extended-length paths if 
+	// nothing in the path exists.
+	vol := filepath.VolumeName(name)
+	i := len(vol) + 1
+	for !os.IsPathSeparator(name[i]) {
+		i++
+	}
+	baseDir := filepath.Join(vol, name[len(vol)+1 : i])
+	
+	if _, err := Stat(baseDir); err != nil {
+        	if err := Mkdir(baseDir); err != nil {
+        		return err
+        	}
+    	}
+	
 	name, err := normPath(name)
 	if err != nil {
 		return err

--- a/oswrap/oswrap_windows.go
+++ b/oswrap/oswrap_windows.go
@@ -6,8 +6,8 @@
 package oswrap
 
 import (
-	"path/filepath"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -82,21 +82,21 @@ func Mkdir(name string, mode os.FileMode) error {
 
 // MkdirAll calls os.MkdirAll with name normalized
 func MkdirAll(name string, mode os.FileMode) error {
-	// os.MkdirAll does not work with extended-length paths if 
+	// os.MkdirAll does not work with extended-length paths if
 	// nothing in the path exists.
 	vol := filepath.VolumeName(name)
 	i := len(vol) + 1
 	for !os.IsPathSeparator(name[i]) {
 		i++
 	}
-	baseDir := filepath.Join(vol, name[len(vol)+1 : i])
-	
+	baseDir := name[:i]
+
 	if _, err := Stat(baseDir); err != nil {
-        	if err := Mkdir(baseDir, mode); err != nil {
-        		return err
-        	}
-    	}
-	
+		if err := Mkdir(baseDir, mode); err != nil {
+			return err
+		}
+	}
+
 	name, err := normPath(name)
 	if err != nil {
 		return err
@@ -116,7 +116,6 @@ func Rename(oldpath, newpath string) error {
 	}
 	return os.Rename(oldpath, newpath)
 }
-
 
 // Lstat calls os.Lstat with name normalized
 func Lstat(name string) (os.FileInfo, error) {

--- a/oswrap/oswrap_windows.go
+++ b/oswrap/oswrap_windows.go
@@ -92,7 +92,7 @@ func MkdirAll(name string, mode os.FileMode) error {
 	baseDir := filepath.Join(vol, name[len(vol)+1 : i])
 	
 	if _, err := Stat(baseDir); err != nil {
-        	if err := Mkdir(baseDir); err != nil {
+        	if err := Mkdir(baseDir, mode); err != nil {
         		return err
         	}
     	}

--- a/remove/remove.go
+++ b/remove/remove.go
@@ -22,9 +22,9 @@ import (
 	"github.com/google/googet/client"
 	"github.com/google/googet/download"
 	"github.com/google/googet/goolib"
+	"github.com/google/googet/oswrap"
 	"github.com/google/googet/system"
 	"github.com/google/logger"
-	"github.com/google/googet/oswrap"
 )
 
 func uninstallPkg(pi goolib.PackageInfo, state *client.GooGetState, dbOnly bool) error {

--- a/remove/remove_test.go
+++ b/remove/remove_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/google/googet/client"
 	"github.com/google/googet/goolib"
-	"github.com/google/logger"
 	"github.com/google/googet/oswrap"
+	"github.com/google/logger"
 )
 
 func init() {

--- a/server/gooserve.go
+++ b/server/gooserve.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	"github.com/google/googet/goolib"
-	"github.com/google/logger"
 	"github.com/google/googet/oswrap"
+	"github.com/google/logger"
 )
 
 var (
@@ -146,7 +146,7 @@ func main() {
 		}
 	}()
 
-  packageDir := filepath.Join(*root, "packages")
+	packageDir := filepath.Join(*root, "packages")
 	if err := runSync(packageDir); err != nil {
 		logger.Error(err)
 	}

--- a/system/system_linux.go
+++ b/system/system_linux.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/google/googet/client"
 	"github.com/google/googet/goolib"
-	"github.com/google/logger"
 	"github.com/google/googet/oswrap"
+	"github.com/google/logger"
 )
 
 // Install performs a system specfic install given a package extraction directory and an PkgSpec struct.

--- a/system/system_windows.go
+++ b/system/system_windows.go
@@ -26,8 +26,8 @@ import (
 	"github.com/StackExchange/wmi"
 	"github.com/google/googet/client"
 	"github.com/google/googet/goolib"
-	"github.com/google/logger"
 	"github.com/google/googet/oswrap"
+	"github.com/google/logger"
 	"golang.org/x/sys/windows/registry"
 )
 


### PR DESCRIPTION
os.MkdirAll does not work with extended-length paths if nothing in the path exists