### PR TITLE
Expand usage of msi success codes.

### DIFF
--- a/googet.goospec
+++ b/googet.goospec
@@ -12,6 +12,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.9.2 - Expand MSI success code usage to MSU and EXE files.",
     "2.9.1 - Add ability to add proxy server.",
     "2.9.0 - Add addrepo, rmrepo, and listrepos commands.",
     "      - Use args instead of flags for available and installed commands.",

--- a/googet.goospec
+++ b/googet.goospec
@@ -1,6 +1,6 @@
 {
   "name": "googet",
-  "version": "2.9.4@1",
+  "version": "2.9.5@1",
   "arch": "x86_64",
   "authors": "ajackura@google.com",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -12,7 +12,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
-    "2.9.2 - Expand MSI success code usage to MSU and EXE files.",
+    "2.9.5 - Expand MSI success code usage to MSU and EXE files.",
     "2.9.1 - Add ability to add proxy server.",
     "2.9.0 - Add addrepo, rmrepo, and listrepos commands.",
     "      - Use args instead of flags for available and installed commands.",

--- a/system/system_windows.go
+++ b/system/system_windows.go
@@ -88,20 +88,19 @@ func Install(dir string, ps *goolib.PkgSpec) error {
 	}()
 	s := filepath.Join(dir, in.Path)
 	msiLog := filepath.Join(dir, "msi_install.log")
+	ec := append(msiSuccessCodes, in.ExitCodes...)
 	switch filepath.Ext(s) {
 	case ".msi":
 		args := append([]string{"/i", s, "/qn", "/norestart", "/log", msiLog}, in.Args...)
-		ec := append(msiSuccessCodes, in.ExitCodes...)
 		err = goolib.Run(exec.Command("msiexec", args...), ec, out)
 	case ".msp":
 		args := append([]string{"/update", s, "/qn", "/norestart", "/log", msiLog}, in.Args...)
-		ec := append(msiSuccessCodes, in.ExitCodes...)
 		err = goolib.Run(exec.Command("msiexec", args...), ec, out)
 	case ".msu":
 		args := append([]string{s, "/quiet", "/norestart"}, in.Args...)
-		err = goolib.Run(exec.Command("wusa", args...), in.ExitCodes, out)
+		err = goolib.Run(exec.Command("wusa", args...), ec, out)
 	case ".exe":
-		err = goolib.Run(exec.Command(s, in.Args...), in.ExitCodes, out)
+		err = goolib.Run(exec.Command(s, in.Args...), ec, out)
 	default:
 		err = goolib.Exec(s, in.Args, in.ExitCodes, out)
 	}
@@ -136,17 +135,17 @@ func Uninstall(st client.PackageState) error {
 		}
 	}()
 	s := filepath.Join(st.UnpackDir, un.Path)
+	ec := append(msiSuccessCodes, un.ExitCodes...)
 	switch filepath.Ext(s) {
 	case ".msi":
 		msiLog := filepath.Join(st.UnpackDir, "msi_uninstall.log")
 		args := append([]string{"/x", s, "/qn", "/norestart", "/log", msiLog}, un.Args...)
-		ec := append(msiSuccessCodes, un.ExitCodes...)
 		err = goolib.Run(exec.Command("msiexec", args...), ec, out)
 	case ".msu":
 		args := append([]string{s, "/uninstall", "/quiet", "/norestart"}, un.Args...)
-		err = goolib.Run(exec.Command("wusa", args...), un.ExitCodes, out)
+		err = goolib.Run(exec.Command("wusa", args...), ec, out)
 	case ".exe":
-		err = goolib.Run(exec.Command(s, un.Args...), un.ExitCodes, out)
+		err = goolib.Run(exec.Command(s, un.Args...), ec, out)
 	default:
 		err = goolib.Exec(filepath.Join(st.UnpackDir, un.Path), un.Args, un.ExitCodes, out)
 	}


### PR DESCRIPTION
Both msu and exe files are known to use msi success codes when restarts
are required (i.e. the .net redist). Ensure these files correctly report
success to googet when installing/removing.