### PR TITLE
Fix semver patch metadata handling.

### DIFF
--- a/googet.goospec
+++ b/googet.goospec
@@ -1,6 +1,6 @@
 {
   "name": "googet",
-  "version": "2.10.0@1",
+  "version": "2.10.1@1",
   "arch": "x86_64",
   "authors": "ajackura@google.com",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -12,6 +12,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.10.1 - Semver compatibility bug fix for '0' patch numbers.",
     "2.10.0 - Files that had to be moved during install are cleaned up at end of package install or next reboot.",
     "       - When replacing files during install files are not moved between volumes.",
     "2.9.5 - Expand MSI success code usage to MSU and EXE files.",
@@ -39,7 +40,7 @@
   ],
   "sources": [{
       "include": [
-        "googet.exe", 
+        "googet.exe",
         "install.ps1"
       ]
   }],

--- a/goolib/goospec.go
+++ b/goolib/goospec.go
@@ -136,6 +136,12 @@ func Compare(v1, v2 string) (int, error) {
 }
 
 func fixVer(ver string) string {
+	suffix := ""
+	// Patch number can contain PreRelease/Build meta data suffix.
+	if i := strings.IndexAny(ver, "+-"); i != -1 {
+		suffix = ver[i:]
+		ver = ver[:i]
+	}
 	out := []string{"0", "0", "0"}
 	nums := strings.SplitN(ver, ".", 3)
 	offset := len(out) - len(nums)
@@ -146,10 +152,14 @@ func fixVer(ver string) string {
 		}
 		out[i+offset] = trimmed
 	}
-	return strings.Join(out, ".")
+	return strings.Join(out, ".") + suffix
 }
 
-// ParseVersion parses the string version into goospec.Version.
+// ParseVersion parses the string version into goospec.Version. ParseVersion
+// attempts to fix non-compliant Semver strings by removing leading zeros from
+// components, and replacing any missing components with zero values after
+// using existing components for the least significant components first (i.e.
+// "1" will become "0.0.1", not "1.0.0").
 func ParseVersion(ver string) (Version, error) {
 	v := strings.SplitN(ver, "@", 2)
 	v[0] = fixVer(v[0])

--- a/goolib/goospec_test.go
+++ b/goolib/goospec_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/blang/semver"
 )
 
-func mkVer(maj, min, pat uint64, rel int) Version {
+func mkVer(sem string, rel int) Version {
 	return Version{
-		Semver: semver.Version{Major: maj, Minor: min, Patch: pat},
+		Semver: semver.MustParse(sem),
 		GsVer:  rel,
 	}
 }
@@ -35,18 +35,22 @@ func TestParseVersion(t *testing.T) {
 		ver string
 		res Version
 	}{
-		{"1.2.3@4", mkVer(1, 2, 3, 4)},
-		{"1.2.3", mkVer(1, 2, 3, 0)},
-		{"1.02.3", mkVer(1, 2, 3, 0)},
-		{"1.2@7", mkVer(0, 1, 2, 7)},
+		{"1.2.3@4", mkVer("1.2.3", 4)},
+		{"1.2.3", mkVer("1.2.3", 0)},
+		{"1.02.3", mkVer("1.2.3", 0)},
+		{"1.2@7", mkVer("0.1.2", 7)},
+		{"1.2.0", mkVer("1.2.0", 0)},
+		{"1.2.3+1", mkVer("1.2.3+1", 0)},
+		{"1.2.03-1", mkVer("1.2.3-1", 0)},
+		{"1.2.3+4@5", mkVer("1.2.3+4", 5)},
 	}
 	for _, tt := range table {
 		v, err := ParseVersion(tt.ver)
 		if err != nil {
-			t.Errorf("error parsing version: %v", err)
+			t.Errorf("ParseVersion(%v): %v", tt.ver, err)
 		}
 		if !reflect.DeepEqual(v, tt.res) {
-			t.Errorf("parsed version unexpected: got %v, want %v", v, tt.res)
+			t.Errorf("ParseVersion(%v) = %v, want %v", tt.ver, v, tt.res)
 		}
 	}
 }


### PR DESCRIPTION
Trimming leading zeros failed to take pre-release/build metadata into
account in the patch component and resulted in failed parsing of valid
version strings.