### PR TITLE
Set secure defaults when downloading from a repo

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -36,7 +36,7 @@ import (
 )
 
 // Package downloads a package from the given url,
-// if a SHA256 checksum is provided it will be checked.
+// the provided SHA256 checksum will be checked during download.
 func Package(pkgURL, dst, chksum string, proxyServer string) error {
 	httpClient := &http.Client{}
 	if proxyServer != "" {
@@ -55,10 +55,7 @@ func Package(pkgURL, dst, chksum string, proxyServer string) error {
 	if err := oswrap.RemoveAll(dst); err != nil {
 		return err
 	}
-	if err := download(resp.Body, dst, chksum, proxyServer); err != nil {
-		return err
-	}
-	return nil
+	return download(resp.Body, dst, chksum, proxyServer)
 }
 
 // FromRepo downloads a package from a repo.
@@ -103,7 +100,7 @@ func download(r io.Reader, p, chksum string, proxyServer string) (err error) {
 
 	logger.Infof("Successfully downloaded %s", humanize.IBytes(uint64(b)))
 
-	if chksum != "" && hex.EncodeToString(hash.Sum(nil)) != chksum {
+	if hex.EncodeToString(hash.Sum(nil)) != chksum {
 		return errors.New("checksum of downloaded file does not match expected checksum")
 	}
 	return nil

--- a/googet.goospec
+++ b/googet.goospec
@@ -1,6 +1,6 @@
 {
   "name": "googet",
-  "version": "2.10.1@1",
+  "version": "2.11.0@1",
   "arch": "x86_64",
   "authors": "ajackura@google.com",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -12,6 +12,8 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.11.0 - Add allowunsafeurl config option to enable HTTP repos, otherwise disable.",
+    "       - Force the use of a package checksum when downloading from a repository.",
     "2.10.1 - Semver compatibility bug fix for '0' patch numbers.",
     "2.10.0 - Files that had to be moved during install are cleaned up at end of package install or next reboot.",
     "       - When replacing files during install files are not moved between volumes.",

--- a/goolib/goospec.go
+++ b/goolib/goospec.go
@@ -49,7 +49,7 @@ type GooSpec struct {
 	PackageSpec *PkgSpec
 }
 
-// RepoSpec is the repository specfication of a package.
+// RepoSpec is the repository specification of a package.
 type RepoSpec struct {
 	Checksum, Source string
 	PackageSpec      *PkgSpec
@@ -305,7 +305,7 @@ func (spec *PkgSpec) verify() error {
 		return fmt.Errorf("invalid architecture: %q", spec.Arch)
 	}
 	if spec.Version == "" {
-		return errors.New("Version string empty")
+		return errors.New("version string empty")
 	}
 	if _, err := ParseVersion(spec.Version); err != nil {
 		return fmt.Errorf("can't parse %q: %v", spec.Version, err)

--- a/goolib/goospec_test.go
+++ b/goolib/goospec_test.go
@@ -100,7 +100,7 @@ func TestBadVerify(t *testing.T) {
 				Arch: "noarch",
 				Name: "name",
 			},
-		}, "Version string empty"},
+		}, "version string empty"},
 		{GooSpec{
 			PackageSpec: &PkgSpec{
 				Arch:    "noarch",

--- a/install/install.go
+++ b/install/install.go
@@ -179,7 +179,7 @@ func FromDisk(arg, cache string, state *client.GooGetState, dbOnly, ri bool) err
 			logger.Infof("Dependency met: %s.%s with version greater than %s installed", pi.Name, pi.Arch, ver)
 			continue
 		}
-		return fmt.Errorf("Package dependency %s %s (min version %s) not installed.\n", pi.Name, pi.Arch, ver)
+		return fmt.Errorf("package dependency %s %s (min version %s) not installed", pi.Name, pi.Arch, ver)
 	}
 
 	dst := filepath.Join(cache, goolib.PackageInfo{Name: zs.Name, Arch: zs.Arch, Ver: zs.Version}.PkgName())


### PR DESCRIPTION
Add allowunsafeurl config option to enable HTTP repos, otherwise disable
Force the use of a package checksum when downloading from a repository
Style fixes