### PR TITLE
Add Conflicts and Replaces to the PkgSpec

### DIFF
--- a/googet.goospec
+++ b/googet.goospec
@@ -1,6 +1,6 @@
 {
   "name": "googet",
-  "version": "2.12.0@1",
+  "version": "2.13.0@1",
   "arch": "x86_64",
   "authors": "ajackura@google.com",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -12,6 +12,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.13.0 - Add Conflicts and Replaces fields to the GooGet PkgSpec.",
     "2.12.0 - Store goo files unextracted in cache, ensure checksum match on reinstall.",
     "2.11.0 - Add allowunsafeurl config option to enable HTTP repos, otherwise disable.",
     "       - Force the use of a package checksum when downloading from a repository.",

--- a/googet_clean.go
+++ b/googet_clean.go
@@ -66,7 +66,7 @@ func cleanPackages(pl []string) {
 
 	for _, pkg := range *state {
 		if goolib.ContainsString(pkg.PackageSpec.Name, pl) {
-			if err := oswrap.RemoveAll(pkg.UnpackDir); err != nil {
+			if err := oswrap.RemoveAll(pkg.LocalPath); err != nil {
 				logger.Error(err)
 			}
 		}
@@ -95,7 +95,7 @@ func cleanOld() {
 
 	var il []string
 	for _, pkg := range *state {
-		il = append(il, pkg.UnpackDir)
+		il = append(il, pkg.LocalPath)
 	}
 	clean(il)
 }

--- a/googet_test.go
+++ b/googet_test.go
@@ -225,19 +225,23 @@ func TestCleanOld(t *testing.T) {
 	}
 	defer oswrap.RemoveAll(rootDir)
 
-	wantDir := filepath.Join(rootDir, cacheDir, "want")
+	wantFile := filepath.Join(rootDir, cacheDir, "want.goo")
 	notWantDir := filepath.Join(rootDir, cacheDir, "notWant")
+	notWantFile := filepath.Join(rootDir, cacheDir, "notWant.goo")
 
-	if err := oswrap.MkdirAll(wantDir, 0700); err != nil {
+	if err := oswrap.MkdirAll(notWantDir, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := oswrap.MkdirAll(notWantDir, 0700); err != nil {
+	if err := ioutil.WriteFile(notWantFile, nil, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(wantFile, nil, 0700); err != nil {
 		t.Fatal(err)
 	}
 
 	state := &client.GooGetState{
 		{
-			UnpackDir: wantDir,
+			LocalPath: wantFile,
 		},
 	}
 
@@ -247,12 +251,16 @@ func TestCleanOld(t *testing.T) {
 
 	cleanOld()
 
-	if _, err := oswrap.Stat(wantDir); err != nil {
+	if _, err := oswrap.Stat(wantFile); err != nil {
 		t.Errorf("cleanOld removed wantDir, Stat err: %v", err)
 	}
 
 	if _, err := oswrap.Stat(notWantDir); err == nil {
 		t.Errorf("cleanOld did not remove notWantDir")
+	}
+
+	if _, err := oswrap.Stat(notWantFile); err == nil {
+		t.Errorf("cleanOld did not remove notWantFile")
 	}
 }
 
@@ -264,25 +272,28 @@ func TestCleanPackages(t *testing.T) {
 	}
 	defer oswrap.RemoveAll(rootDir)
 
-	wantDir := filepath.Join(rootDir, cacheDir, "want")
-	notWantDir := filepath.Join(rootDir, cacheDir, "notWant")
+	wantFile := filepath.Join(rootDir, cacheDir, "want")
+	notWantFile := filepath.Join(rootDir, cacheDir, "notWant")
 
-	if err := oswrap.MkdirAll(wantDir, 0700); err != nil {
+	if err := oswrap.MkdirAll(filepath.Join(rootDir, cacheDir), 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := oswrap.MkdirAll(notWantDir, 0700); err != nil {
+	if err := ioutil.WriteFile(wantFile, nil, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(notWantFile, nil, 0700); err != nil {
 		t.Fatal(err)
 	}
 
 	state := &client.GooGetState{
 		{
-			UnpackDir: wantDir,
+			LocalPath: wantFile,
 			PackageSpec: &goolib.PkgSpec{
 				Name: "want",
 			},
 		},
 		{
-			UnpackDir: notWantDir,
+			LocalPath: notWantFile,
 			PackageSpec: &goolib.PkgSpec{
 				Name: "notWant",
 			},
@@ -295,11 +306,11 @@ func TestCleanPackages(t *testing.T) {
 
 	cleanPackages([]string{"notWant"})
 
-	if _, err := oswrap.Stat(wantDir); err != nil {
+	if _, err := oswrap.Stat(wantFile); err != nil {
 		t.Errorf("cleanPackages removed wantDir, Stat err: %v", err)
 	}
 
-	if _, err := oswrap.Stat(notWantDir); err == nil {
+	if _, err := oswrap.Stat(notWantFile); err == nil {
 		t.Errorf("cleanPackages did not remove notWantDir")
 	}
 }

--- a/goolib/goolib.go
+++ b/goolib/goolib.go
@@ -102,6 +102,16 @@ type PackageInfo struct {
 	Name, Arch, Ver string
 }
 
+func (pi PackageInfo) String() string {
+	if pi.Arch != "" && pi.Ver != "" {
+		return fmt.Sprintf("%s.%s.%s", pi.Name, pi.Arch, pi.Ver)
+	}
+	if pi.Arch != "" {
+		return fmt.Sprintf("%s.%s", pi.Name, pi.Arch)
+	}
+	return pi.Name
+}
+
 // PkgName returns the proper goo package name.
 func (pi PackageInfo) PkgName() string {
 	return fmt.Sprintf("%s.%s.%s.goo", pi.Name, pi.Arch, pi.Ver)

--- a/goolib/goospec.go
+++ b/goolib/goospec.go
@@ -68,7 +68,7 @@ const (
 
 var validArch = []string{"noarch", "x86_64", "x86_32", "arm"}
 
-// PkgSpec is the internal package specification.
+// PkgSpec is an individual package specification.
 type PkgSpec struct {
 	Name            string
 	Version         string
@@ -80,6 +80,8 @@ type PkgSpec struct {
 	Owners          string            `json:",omitempty"`
 	Tags            map[string][]byte `json:",omitempty"`
 	PkgDependencies map[string]string `json:",omitempty"`
+	Replaces        []string
+	Conflicts       []string
 	Install         ExecFile
 	Uninstall       ExecFile
 	Files           map[string]string `json:",omitempty"`

--- a/goolib/goospec_test.go
+++ b/goolib/goospec_test.go
@@ -297,6 +297,8 @@ func TestMarshal(t *testing.T) {
 			ReleaseNotes: []string{"1.2.3@4 - something new", "1.2.3@4 - something"},
 			Description:  "blah blah",
 			Owners:       "someone",
+			Replaces:     []string{"foo"},
+			Conflicts:    []string{"bar"},
 			Install: ExecFile{
 				Path: "install.ps1",
 			},
@@ -315,6 +317,12 @@ func TestMarshal(t *testing.T) {
     ],
     "Description": "blah blah",
     "Owners": "someone",
+    "Replaces": [
+      "foo"
+    ],
+    "Conflicts": [
+      "bar"
+    ],
     "Install": {
       "Path": "install.ps1"
     },

--- a/remove/remove_test.go
+++ b/remove/remove_test.go
@@ -14,7 +14,11 @@ limitations under the License.
 package remove
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
 	"io/ioutil"
+	"log"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -49,9 +53,42 @@ func TestUninstallPkg(t *testing.T) {
 		t.Fatalf("Failed to create test folder: %v", err)
 	}
 
-	testFile := filepath.Join(testFolder3, "foo")
-	if err := ioutil.WriteFile(testFile, []byte{}, 0666); err != nil {
+	f, err := oswrap.Create(filepath.Join(src, "test.goo"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer oswrap.Remove(f.Name())
+
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	testFile, err := oswrap.Create(filepath.Join(testFolder3, "foo"))
+	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	fi, err := testFile.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fih, err := tar.FileInfoHeader(fi, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.WriteHeader(fih); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(tw, testFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := testFile.Close(); err != nil {
+		t.Fatalf("Failed to close test file: %v", err)
+	}
+
+	tw.Close()
+	gw.Close()
+	if err := f.Close(); err != nil {
+		log.Fatal(err)
 	}
 
 	st := &client.GooGetState{
@@ -60,13 +97,13 @@ func TestUninstallPkg(t *testing.T) {
 				Name: "foo",
 			},
 			InstalledFiles: map[string]string{
-				testFile:    "chksum",
-				testFolder:  "",
-				testFolder2: "",
-				testFolder3: "",
-				dst:         "",
+				testFile.Name(): "chksum",
+				testFolder:      "",
+				testFolder2:     "",
+				testFolder3:     "",
+				dst:             "",
 			},
-			UnpackDir: dst,
+			LocalPath: f.Name(),
 		},
 	}
 
@@ -74,7 +111,7 @@ func TestUninstallPkg(t *testing.T) {
 		t.Fatalf("Error running uninstallPkg: %v", err)
 	}
 
-	for _, n := range []string{testFile, dst} {
+	for _, n := range []string{testFile.Name(), dst} {
 		if _, err := oswrap.Stat(n); err == nil {
 			t.Errorf("%s was not removed", n)
 		}

--- a/system/system_linux.go
+++ b/system/system_linux.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/google/googet/client"
 	"github.com/google/googet/goolib"
 	"github.com/google/googet/oswrap"
 	"github.com/google/logger"
@@ -51,16 +50,15 @@ func Install(dir string, ps *goolib.PkgSpec) error {
 }
 
 // Uninstall performs a system specfic uninstall given a packages PackageState.
-func Uninstall(st client.PackageState) error {
-	un := st.PackageSpec.Uninstall
+func Uninstall(dir string, ps *goolib.PkgSpec) error {
+	un := ps.Uninstall
 	if un.Path == "" {
-		logger.Info("No uninstaller specified")
 		return nil
 	}
 
 	logger.Infof("Running uninstall: %q", un.Path)
 	// logging is only useful for failed uninstalls
-	out, err := oswrap.Create(filepath.Join(st.UnpackDir, "googet_remove.log"))
+	out, err := oswrap.Create(filepath.Join(dir, "googet_remove.log"))
 	if err != nil {
 		return err
 	}
@@ -69,7 +67,7 @@ func Uninstall(st client.PackageState) error {
 			logger.Error(err)
 		}
 	}()
-	return goolib.Exec(filepath.Join(st.UnpackDir, un.Path), un.Args, un.ExitCodes, out)
+	return goolib.Exec(filepath.Join(dir, un.Path), un.Args, un.ExitCodes, out)
 }
 
 // InstallableArchs returns a slice of archs supported by this machine.


### PR DESCRIPTION
Package Conflicts will prevent the package from being installed if a conflicting package is already installed
Package Replaces will remove any packages that are replaced by one being installed 