### PR TITLE
Use correct case for 'allowunsafeurl' in error

### DIFF
--- a/googet.go
+++ b/googet.go
@@ -162,7 +162,7 @@ func repoList(dir string) ([]string, error) {
 		var srl []string
 		for _, r := range rl {
 			if strings.ToLower(r[0:5]) != "https" {
-				logger.Errorf("%s will not be used as a repository, only https endpoints will be used unless AllowUnsafeURL is set to 'true' in googet.conf", r)
+				logger.Errorf("%s will not be used as a repository, only https endpoints will be used unless 'allowunsafeurl' is set to 'true' in googet.conf", r)
 				continue
 			}
 			srl = append(srl, r)


### PR DESCRIPTION
'AllowUnsafeURL' in googet.conf doesn't work because
go-yaml/yaml's Unmarshal() expects keys to be all
lowercase. The error message about unsafe repos was
therefore misleading. This change informs the user
of the correct key to put in googet.conf.