### PR TITLE
Corrected 'Source' path in packages with -root

### DIFF
--- a/server/gooserve.go
+++ b/server/gooserve.go
@@ -105,7 +105,7 @@ func runSync(packageDir string) error {
 		wg.Add(1)
 		go func(pkg string) {
 			defer wg.Done()
-			if err := packageInfo(pkg, packageDir); err != nil {
+			if err := packageInfo(pkg); err != nil {
 				logger.Error(err)
 			}
 		}(pkg)

--- a/server/gooserve.go
+++ b/server/gooserve.go
@@ -60,7 +60,7 @@ func (r *repoPackages) add(src, chksum string, spec *goolib.PkgSpec) {
 	})
 }
 
-func packageInfo(pkgPath, packageDir string) error {
+func packageInfo(pkgPath string) error {
 	pkg := filepath.Base(pkgPath)
 	pi := goolib.PkgNameSplit(strings.TrimSuffix(pkg, ".goo"))
 


### PR DESCRIPTION
Code previously put the local filesystem path rather than the path
relative to the web server root into the 'Source' attribute of the
metadata JSON.