### PR TITLE
Made listening address configurable

### DIFF
--- a/server/gooserve.go
+++ b/server/gooserve.go
@@ -36,6 +36,7 @@ var (
 	interval    = flag.Duration("interval", 5*time.Minute, "duration between refresh runs")
 	verbose     = flag.Bool("verbose", false, "print info level logs to stdout")
 	systemLog   = flag.Bool("system_log", false, "log to Linux Syslog or Windows Event Log")
+	address     = flag.String("address", "", "address to listen on")
 	port        = flag.Int("port", 8000, "listen port")
 	repoName    = flag.String("repo_name", "repo", "name of the repo to setup")
 	packagePath = flag.String("package_path", "packages", "path under both the filesystem (-root flag) and webserver root where packages are located")
@@ -148,7 +149,7 @@ func main() {
 	prefix := "/" + *packagePath + "/"
 	http.Handle(prefix, http.StripPrefix(prefix, http.FileServer(http.Dir(packageDir))))
 	go func() {
-		err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil)
+		err := http.ListenAndServe(fmt.Sprintf("%s:%d", *address, *port), nil)
 		if err != nil {
 			logger.Fatal(err)
 		}


### PR DESCRIPTION
The client disallows http (no 's') by default but the server only
serves http. The server is therefore likely to be configured
behind a revers proxy. A defense-in-depth approach involves
having such services listen only on localhost. This change makes
the address the server listens on configurable to support such a
configuration.