### PR TITLE
Fixes and warnings for utf-8 only index files

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,18 +1,29 @@
 # GooGet Server
 
-This is a simple example of what a GooGet server looks like. 
-The server looks for a folder in it's root directory called 'packages', 
-creating it if necesary. The directory contents are read on a set 
+This is a simple example of what a GooGet server looks like.
+The server looks for a folder in it's root directory called 'packages',
+creating it if necesary. The directory contents are read on a set
 interval and all .goo packages served in the repo 'repo'.
-You can then point a client at http://localhost:8000/repo, or view 
+You can then point a client at http://localhost:8000/repo, or view
 http://localhost:8000/repo/index in a browser.
 
-Improvements to this design would include only updating the repository on 
+Improvements to this design would include only updating the repository on
 a package change as well as providing and api for adding/removing packages.
 
 The server code can also be used to generate a package index that can be used
 by a web server or Google Cloud Storage like so:
 
+```dos
+mkdir -p /tmp/goorepo/packages/
+cp /somewhere/else/*.goo /tmp/goorepo/packages/
+go run gooserve.go -root /tmp/goorepo/ -save_index /tmp/goorepo/index
+gsutil rsync -r /tmp/goorepo/ gs://my-bucket/goorepo/
 ```
-go run gooserve.go -root /path/to/my/repo/ -dump_index > /path/to/my/repo/index
+WARNING: If you use Powershell and -dump_index instead of -save_index, make sure to save the file as UTF-8. If you see an error like *ERROR: 2018/05/26 09:23:56.329402 client.go:100: error reading repo "gs://my-bucket/googet/": invalid character 'ÿ' looking for beginning of value*, that's likely the problem.
+
+```powershell
+# Don't do this, your index file will be UTF-16, which googet won't handle
+go run gooserve.go -root /tmp/goorepo/ -save_index /tmp/goorepo/index > this_index_will_be_corrupt
+# Preserving the encoding fixes the problem
+go run gooserve.go -root /tmp/goorepo/ -save_index /tmp/goorepo/index | Out-File index -Encoding OEM
 ```

--- a/server/gooserve.go
+++ b/server/gooserve.go
@@ -41,6 +41,7 @@ var (
 	repoName    = flag.String("repo_name", "repo", "name of the repo to setup")
 	packagePath = flag.String("package_path", "packages", "path under both the filesystem (-root flag) and webserver root where packages are located")
 	dumpIndex   = flag.Bool("dump_index", false, "dump the package index to stdout and quit")
+	saveIndex   = flag.String("save_index", "", "save the package index to the specified file and quit")
 
 	repoContents *repoPackages
 )
@@ -145,12 +146,20 @@ func main() {
 	if err := runSync(packageDir); err != nil {
 		logger.Error(err)
 	}
-	if *dumpIndex {
+	if *dumpIndex || *saveIndex != "" {
 		out, err := json.MarshalIndent(repoContents.rs, "", "  ")
 		if err != nil {
 			logger.Fatal(err)
 		}
-		fmt.Println(string(out))
+		if *dumpIndex {
+			fmt.Println(string(out))
+		}
+		if *saveIndex != "" {
+			err := ioutil.WriteFile(*saveIndex, out, 0644)
+			if err != nil {
+				logger.Fatal(err)
+			}
+		}
 		return
 	}
 


### PR DESCRIPTION
Powershell redirection results in UTF-16 index files,
which golang's JSON parser doesn't handle. Added a
-save_index option in addition to the -dump_index
option to make it easy to avoid the problem. Also
updated README.md to use -save_index and warned about
using -dump_index with Powershell.