### PR TITLE
Fixed issue with trailing slash in repo paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ Googet supports using Google Cloud Storage as its server.
 
 ```
 set GOOREPO=%TEMP%\googet-repo
+set REPONAME=my_repo
+mkdir %GOOREPO%\%REPONAME%
 mkdir %GOOREPO%\packages
 go run goopack/goopack.go googet.goospec
 copy *.goo %GOOREPO%\packages
-go run server\gooserve.go -root %GOOREPO% -dump_index > %GOOREPO%\index
+go run server\gooserve.go -root %GOOREPO% -save_index %GOOREPO%\%REPONAME%\index
 gsutil mb --project my-project my-googet-server
 gsutil rsync -r %GOOREPO% gs://my-googet-server
 ./googet.exe addrepo gcs gs://my-googet-server

--- a/download/download.go
+++ b/download/download.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -109,7 +108,7 @@ func FromRepo(ctx context.Context, rs goolib.RepoSpec, repo, dir string, proxySe
 		Scheme:  repoURL.Scheme,
 		Host:    repoURL.Host,
 		User:    repoURL.User,
-		RawPath: path.Join(path.Dir(regexp.MustCompile("/*$").ReplaceAllString(repoURL.EscapedPath(), "")), rs.Source),
+		RawPath: path.Join(path.Dir(strings.TrimSuffix(repoURL.EscapedPath(), "/")), rs.Source),
 	}
 	pkgURL.Path, err = url.PathUnescape(pkgURL.RawPath)
 	if err != nil {

--- a/download/download.go
+++ b/download/download.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -102,11 +103,14 @@ func FromRepo(ctx context.Context, rs goolib.RepoSpec, repo, dir string, proxySe
 	if err != nil {
 		return "", err
 	}
+	// We strip training slashes to make sure path.Dir() removes the final component (the repo name).
+	// Otherwise '/myrepo' would correctly resolve to '/', but '/myrepo/' would incorrectly resolve to '/myrepo'
+	normalize := regexp.MustCompile("/*$")
 	pkgURL := &url.URL{
 		Scheme:  repoURL.Scheme,
 		Host:    repoURL.Host,
 		User:    repoURL.User,
-		RawPath: path.Join(path.Dir(repoURL.EscapedPath()), rs.Source),
+		RawPath: path.Join(path.Dir(normalize.ReplaceAllString(repoURL.EscapedPath(),"")), rs.Source),
 	}
 	pkgURL.Path, err = url.PathUnescape(pkgURL.RawPath)
 	if err != nil {

--- a/download/download.go
+++ b/download/download.go
@@ -110,7 +110,7 @@ func FromRepo(ctx context.Context, rs goolib.RepoSpec, repo, dir string, proxySe
 		Scheme:  repoURL.Scheme,
 		Host:    repoURL.Host,
 		User:    repoURL.User,
-		RawPath: path.Join(path.Dir(normalize.ReplaceAllString(repoURL.EscapedPath(),"")), rs.Source),
+		RawPath: path.Join(path.Dir(normalize.ReplaceAllString(repoURL.EscapedPath(), "")), rs.Source),
 	}
 	pkgURL.Path, err = url.PathUnescape(pkgURL.RawPath)
 	if err != nil {

--- a/download/download.go
+++ b/download/download.go
@@ -105,12 +105,11 @@ func FromRepo(ctx context.Context, rs goolib.RepoSpec, repo, dir string, proxySe
 	}
 	// We strip training slashes to make sure path.Dir() removes the final component (the repo name).
 	// Otherwise '/myrepo' would correctly resolve to '/', but '/myrepo/' would incorrectly resolve to '/myrepo'
-	normalize := regexp.MustCompile("/*$")
 	pkgURL := &url.URL{
 		Scheme:  repoURL.Scheme,
 		Host:    repoURL.Host,
 		User:    repoURL.User,
-		RawPath: path.Join(path.Dir(normalize.ReplaceAllString(repoURL.EscapedPath(), "")), rs.Source),
+		RawPath: path.Join(path.Dir(regexp.MustCompile("/*$").ReplaceAllString(repoURL.EscapedPath(), "")), rs.Source),
 	}
 	pkgURL.Path, err = url.PathUnescape(pkgURL.RawPath)
 	if err != nil {

--- a/googet.goospec
+++ b/googet.goospec
@@ -1,6 +1,6 @@
 {
   "name": "googet",
-  "version": "2.14.1@1",
+  "version": "2.14.1@2",
   "arch": "x86_64",
   "authors": "ajackura@google.com",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",

--- a/googet.goospec
+++ b/googet.goospec
@@ -1,6 +1,6 @@
 {
   "name": "googet",
-  "version": "2.14.1@2",
+  "version": "2.14.2@1",
   "arch": "x86_64",
   "authors": "ajackura@google.com",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",

--- a/server/README.md
+++ b/server/README.md
@@ -14,9 +14,10 @@ The server code can also be used to generate a package index that can be used
 by a web server or Google Cloud Storage like so:
 
 ```dos
+mkdir -p /tmp/goorepo/myrepo/
 mkdir -p /tmp/goorepo/packages/
 cp /somewhere/else/*.goo /tmp/goorepo/packages/
-go run gooserve.go -root /tmp/goorepo/ -save_index /tmp/goorepo/index
+go run gooserve.go -root /tmp/goorepo/ -save_index /tmp/goorepo/myrepo/index
 gsutil rsync -r /tmp/goorepo/ gs://my-bucket/goorepo/
 ```
 WARNING: If you use Powershell and -dump_index instead of -save_index, make sure to save the file as UTF-8. If you see an error like *ERROR: 2018/05/26 09:23:56.329402 client.go:100: error reading repo "gs://my-bucket/googet/": invalid character 'ÿ' looking for beginning of value*, that's likely the problem.


### PR DESCRIPTION
  * path.Dir() failed to strip the repo name if the repo URL
    contained a trailing slash.
  * Updated GCS repo documentation to include a repo name in the
    path.