### PR TITLE
Add a custom YAML Unmarshaller for repoEntry objects

### DIFF
--- a/googet.go
+++ b/googet.go
@@ -79,10 +79,33 @@ type repoFile struct {
 }
 
 type repoEntry struct {
-	LName string `yaml:"name,omitempty"`
-	LURL  string `yaml:"url,omitempty"`
-	Name  string `yaml:"Name,omitempty"`
-	URL   string `yaml:"URL,omitempty"`
+	Name string
+	URL  string
+}
+
+// UnmarshalYAML provides custom unmarshalling for repoEntry objects.
+func (r *repoEntry) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var u map[string]string
+	if err := unmarshal(&u); err != nil {
+		return err
+	}
+	for k, v := range u {
+		switch key := strings.ToLower(k); key {
+		case "name":
+			r.Name = v
+		case "url":
+			r.URL = v
+		default:
+			return fmt.Errorf("unexpected key in repo entry: %v", key)
+		}
+	}
+	if r.Name == "" {
+		return fmt.Errorf("repo entry missing name: %+v", u)
+	}
+	if r.URL == "" {
+		return fmt.Errorf("repo entry missing url: %+v", u)
+	}
+	return nil
 }
 
 func writeRepoFile(rf repoFile) error {
@@ -115,7 +138,7 @@ func unmarshalRepoFile(p string) (repoFile, error) {
 
 	// Both repoFile and []repoFile are valid for backwards compatibility.
 	var re repoEntry
-	if err := yaml.Unmarshal(b, &re); err == nil && (re.URL != "" || re.LURL != "") {
+	if err := yaml.Unmarshal(b, &re); err == nil && re.URL != "" {
 		return repoFile{fileName: p, repoEntries: []repoEntry{re}}, nil
 	}
 
@@ -153,8 +176,6 @@ func repoList(dir string) ([]string, error) {
 			switch {
 			case re.URL != "":
 				rl = append(rl, re.URL)
-			case re.LURL != "":
-				rl = append(rl, re.LURL)
 			}
 		}
 	}

--- a/googet_install.go
+++ b/googet_install.go
@@ -40,7 +40,7 @@ type installCmd struct {
 func (*installCmd) Name() string     { return "install" }
 func (*installCmd) Synopsis() string { return "download and install a package and its dependencies" }
 func (*installCmd) Usage() string {
-	return fmt.Sprintf("%s install [-reinstall] [-source repo1,repo2...] <name>\n", filepath.Base(os.Args[0]))
+	return fmt.Sprintf("%s install [-reinstall] [-sources repo1,repo2...] <name>\n", filepath.Base(os.Args[0]))
 }
 
 func (cmd *installCmd) SetFlags(f *flag.FlagSet) {


### PR DESCRIPTION
Keys in repo files vary between upper and lower case in the wild. This is currently handled by unmarshalling into a struct with multiple redundant variables hoping to match, but this in turn requires handling the indeterminate contents of repoEntry objects elsewhere in the code. This handling is hit-or-miss, with some repoEntry calls not fully accounting for the various potential contents.

UnmarshalYAML satisfies an interface in the YAML library, and is called automatically during unmarshalling of the type. Here, we force keys to lower, allowing us to always populate .Name and .URL, regardless of what case they're keyed with in the input. 

This fixes a bug or two elsewhere in googet, where LName and LURL were not being handled correctly.