### PR TITLE
Ensure unique cache file for each repo

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,7 @@ package client
 import (
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -105,7 +107,7 @@ func AvailableVersions(ctx context.Context, srcs []string, cacheDir string, cach
 	return rm
 }
 
-func decode(index io.ReadCloser, ct, cf string) ([]goolib.RepoSpec, error) {
+func decode(index io.ReadCloser, ct, url, cf string) ([]goolib.RepoSpec, error) {
 	defer index.Close()
 
 	var dec *json.Decoder
@@ -141,6 +143,13 @@ func decode(index io.ReadCloser, ct, cf string) ([]goolib.RepoSpec, error) {
 		return nil, err
 	}
 
+	// The .url files aren't used by googet but help developers and the
+  // curious figure out which file belongs to which repo/URL.
+	mf := fmt.Sprintf("%s.url", strings.TrimSuffix(cf, filepath.Ext(cf)))
+	if err = ioutil.WriteFile(mf, []byte(url), 0644); err != nil {
+		logger.Errorf("Failed to write '%s': %v", mf, err)
+	}
+
 	return m, f.Close()
 }
 
@@ -148,7 +157,8 @@ func decode(index io.ReadCloser, ct, cf string) ([]goolib.RepoSpec, error) {
 // if mtime is less than cacheLife.
 // Sucessfully unmarshalled contents will be written to a cache.
 func unmarshalRepoPackages(ctx context.Context, p, cacheDir string, cacheLife time.Duration, proxyServer string) ([]goolib.RepoSpec, error) {
-	cf := filepath.Join(cacheDir, filepath.Base(p)+".rs")
+
+	cf := filepath.Join(cacheDir, fmt.Sprintf("%x.rs", sha256.Sum256([]byte(p))))
 
 	fi, err := oswrap.Stat(cf)
 	if err == nil && time.Since(fi.ModTime()) < cacheLife {
@@ -173,7 +183,7 @@ func unmarshalRepoPackages(ctx context.Context, p, cacheDir string, cacheLife ti
 
 	isGCSURL, bucket, object := goolib.SplitGCSUrl(p)
 	if isGCSURL {
-		return unmarshalRepoPackagesGCS(ctx, bucket, object, cf, proxyServer)
+		return unmarshalRepoPackagesGCS(ctx, bucket, object, p, cf, proxyServer)
 	}
 	return unmarshalRepoPackagesHTTP(p, cf, proxyServer)
 }
@@ -211,10 +221,10 @@ func unmarshalRepoPackagesHTTP(repoURL string, cf string, proxyServer string) ([
 		}
 	}
 
-	return decode(res.Body, ct, cf)
+	return decode(res.Body, ct, repoURL, cf)
 }
 
-func unmarshalRepoPackagesGCS(ctx context.Context, bucket, object string, cf string, proxyServer string) ([]goolib.RepoSpec, error) {
+func unmarshalRepoPackagesGCS(ctx context.Context, bucket, object, url, cf string, proxyServer string) ([]goolib.RepoSpec, error) {
 	if proxyServer != "" {
 		logger.Errorf("Proxy server not supported with gs:// URLs, skiping repo 'gs://%s/%s'", bucket, object)
 		var empty []goolib.RepoSpec
@@ -234,7 +244,7 @@ func unmarshalRepoPackagesGCS(ctx context.Context, bucket, object string, cf str
 	indexPath := object + "index.gz"
 	logger.Infof("Fetching 'gs://%s/%s", bucket, indexPath)
 	if r, err := bkt.Object(indexPath).NewReader(ctx); err == nil {
-		return decode(r, "application/x-gzip", cf)
+		return decode(r, "application/x-gzip", url, cf)
 	}
 
 	if gErr, ok := err.(*googleapi.Error); ok && gErr.Code != http.StatusNotFound {
@@ -248,7 +258,7 @@ func unmarshalRepoPackagesGCS(ctx context.Context, bucket, object string, cf str
 		return nil, err
 	}
 
-	return decode(r, "application/json", cf)
+	return decode(r, "application/json", url, cf)
 }
 
 // FindRepoSpec returns the element of pl whose PackageSpec matches pi.

--- a/client/client.go
+++ b/client/client.go
@@ -144,7 +144,7 @@ func decode(index io.ReadCloser, ct, url, cf string) ([]goolib.RepoSpec, error) 
 	}
 
 	// The .url files aren't used by googet but help developers and the
-  // curious figure out which file belongs to which repo/URL.
+	// curious figure out which file belongs to which repo/URL.
 	mf := fmt.Sprintf("%s.url", strings.TrimSuffix(cf, filepath.Ext(cf)))
 	if err = ioutil.WriteFile(mf, []byte(url), 0644); err != nil {
 		logger.Errorf("Failed to write '%s': %v", mf, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -17,7 +17,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -271,7 +273,8 @@ func TestUnmarshalRepoPackagesCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error marshalling json: %v", err)
 	}
-	f, err := oswrap.Create(filepath.Join(tempDir, "test-repo.rs"))
+	url := "http://localhost/test-repo"
+	f, err := oswrap.Create(filepath.Join(tempDir, fmt.Sprintf("%x.rs", sha256.Sum256([]byte(url)))))
 	if err != nil {
 		t.Fatalf("Error creating cache file: %v", err)
 	}
@@ -283,7 +286,7 @@ func TestUnmarshalRepoPackagesCache(t *testing.T) {
 	}
 
 	// No http server as this should use the cached content.
-	got, err := unmarshalRepoPackages(context.Background(), "http://localhost/test-repo", tempDir, cacheLife, proxyServer)
+	got, err := unmarshalRepoPackages(context.Background(), url, tempDir, cacheLife, proxyServer)
 	if err != nil {
 		t.Fatalf("Error running unmarshalRepoPackages: %v", err)
 	}

--- a/googet.goospec
+++ b/googet.goospec
@@ -1,6 +1,6 @@
 {
   "name": "googet",
-  "version": "2.15.0@1",
+  "version": "2.15.1@1",
   "arch": "x86_64",
   "authors": "ajackura@google.com",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -12,6 +12,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.15.1 - Ensure unique cache file for each repo.",
     "2.15.0 - Add verify subcommand.",
     "2.14.1 - Prevent path traversal in package unpack and install/uninstall paths.",
     "2.14.0 - Add support for GCS repositories.",

--- a/goolib/goospec.go
+++ b/goolib/goospec.go
@@ -88,6 +88,10 @@ type PkgSpec struct {
 	Files           map[string]string `json:",omitempty"`
 }
 
+func (ps PkgSpec) String() string {
+	return fmt.Sprintf("%s.%s.%s", ps.Name, ps.Arch, ps.Version)
+}
+
 // ExecFile contains info involved in running a script or binary file.
 type ExecFile struct {
 	Path      string   `json:",omitempty"`


### PR DESCRIPTION
  * Closes #47
  * Use sha256 sum of repo URL for cache file name instead of last
    path component to ensure (mostly) that two distinct repos never
    use the same cache file.

I opted for a hash rather than replacing / with _ because we'd have the same problem with http://pkgs.com/my/repo and http://pkgs.com/my_repo.