### PR TITLE
Enhance writeState to avoid file loss/corruption

### DIFF
--- a/googet.go
+++ b/googet.go
@@ -231,7 +231,7 @@ func writeState(s *client.GooGetState, sf string) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	if err := os.Chmod(newStateFile, 0644); err != nil {
+	if err := os.Chmod(newStateFile, 0664); err != nil {
 		return err
 	}
 	// Back up the old state file so we can recover it if need be

--- a/googet.go
+++ b/googet.go
@@ -219,7 +219,28 @@ func writeState(s *client.GooGetState, sf string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(sf, b, 0664)
+	// Write state to a temporary file first
+	tmp, err := ioutil.TempFile(rootDir, "googet.*.state")
+	if err != nil {
+		return err
+	}
+	newStateFile := tmp.Name()
+	if _, err = tmp.Write(b); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(newStateFile, 0644); err != nil {
+		return err
+	}
+	// Back up the old state file so we can recover it if need be
+	backupStateFile := sf + ".bak"
+	if err = os.Rename(sf, backupStateFile); err != nil {
+		logger.Infof("Unable to back up state file %s to %s. Err: %v", sf, backupStateFile, err)
+	}
+	// Move the new temp file to the live path
+	return os.Rename(newStateFile, sf)
 }
 
 func readState(sf string) (*client.GooGetState, error) {


### PR DESCRIPTION
writeState is fragile because it truncates, then rewrites in-place the
only copy of the state file. Make it more robust by performing the
write to a new file, taking a backup of the original state (that
could be automatically recovered later; not implemented), and then
doing a couple atomic renames of the files themselves. This should
substantially shrink the window for corrupting the live state file.