### PR TITLE
Mitigations for undefined LocalPath in package states

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -165,6 +165,9 @@ func download(r io.Reader, dst, chksum string) (err error) {
 // package name, it returns the path to the extraced directory.
 func ExtractPkg(src string) (dst string, err error) {
 	dst = strings.TrimSuffix(src, filepath.Ext(src))
+	if src == "" || dst == "" {
+		return "", fmt.Errorf("package extraction paths are invalid: src %s, dst %s", src, dst)
+	}
 	if err := oswrap.Mkdir(dst, 0755); err != nil && !os.IsExist(err) {
 		return "", err
 	}

--- a/googet.goospec
+++ b/googet.goospec
@@ -1,6 +1,6 @@
 {
   "name": "googet",
-  "version": "2.16.1@1",
+  "version": "2.16.2@1",
   "arch": "x86_64",
   "authors": "ajackura@google.com",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -12,6 +12,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.16.2 - Mitigations for undefined LocalPath in package states",
     "2.16.1 - Enhance state file handling to minimize loss/corruption",
     "2.16.0 - GooGet release number is now parsed as an int64",
     "2.15.1 - Ensure unique cache file for each repo.",

--- a/remove/remove.go
+++ b/remove/remove.go
@@ -35,9 +35,13 @@ func uninstallPkg(ctx context.Context, pi goolib.PackageInfo, state *client.GooG
 		return fmt.Errorf("package not found in state file: %v", err)
 	}
 	// Fix for package install by older versions of GooGet.
-	if ps.LocalPath == "" {
+	if ps.LocalPath == "" && ps.UnpackDir != "" {
 		ps.LocalPath = ps.UnpackDir + ".goo"
 	}
+	if ps.LocalPath == "" {
+		return fmt.Errorf("no local path available for package %q", pi.Name)
+	}
+
 	if !dbOnly {
 		f, err := os.Open(ps.LocalPath)
 		if err != nil && !os.IsNotExist(err) {


### PR DESCRIPTION
Avoid having remove package attempt to operate on empty path strings if package state goes missing.