### PR TITLE
Handle missing LocalPath state in the reinstall command

### DIFF
--- a/googet.goospec
+++ b/googet.goospec
@@ -12,6 +12,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.16.3 - Handle missing LocalPath state in the reinstall command",
     "2.16.2 - Mitigations for undefined LocalPath in package states",
     "2.16.1 - Enhance state file handling to minimize loss/corruption",
     "2.16.0 - GooGet release number is now parsed as an int64",

--- a/install/install.go
+++ b/install/install.go
@@ -266,9 +266,14 @@ func Reinstall(ctx context.Context, ps client.PackageState, state client.GooGetS
 	pi := goolib.PackageInfo{Name: ps.PackageSpec.Name, Arch: ps.PackageSpec.Arch, Ver: ps.PackageSpec.Version}
 	logger.Infof("Starting reinstall of %s.%s, version %s", pi.Name, pi.Arch, pi.Ver)
 	fmt.Printf("Reinstalling %s.%s %s and dependencies...\n", pi.Name, pi.Arch, pi.Ver)
+
 	// Fix for package install by older versions of GooGet.
-	if ps.LocalPath == "" {
+	if ps.LocalPath == "" && ps.UnpackDir != "" {
 		ps.LocalPath = ps.UnpackDir + ".goo"
+	}
+
+	if ps.LocalPath == "" {
+		return fmt.Errorf("Local path not referenced in state file for %s.%s.%s. Cannot redownload.", pi.Name, pi.Arch, pi.Ver)
 	}
 
 	f, err := os.Open(ps.LocalPath)


### PR DESCRIPTION
Reinstall expects to have a valid LocalPath in the package state, and may attempt to re-download to an invalid path if they aren't set.

Reinstall doesn't have any references to the download directory (cache path) which would enable it to recompute the expected path, so return an error.