### PR TITLE
Add flag to 'googet installed' to list directly-managed files.

### DIFF
--- a/googet.goospec
+++ b/googet.goospec
@@ -1,6 +1,6 @@
 {
   "name": "googet",
-  "version": "2.16.3@1",
+  "version": "2.16.4@1",
   "arch": "x86_64",
   "authors": "ajackura@google.com",
   "license": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -12,6 +12,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.16.4 - Add flag to 'googet installed' to list directly-managed files.",
     "2.16.3 - Handle missing LocalPath state in the reinstall command",
     "2.16.2 - Mitigations for undefined LocalPath in package states",
     "2.16.1 - Enhance state file handling to minimize loss/corruption",

--- a/googet_installed.go
+++ b/googet_installed.go
@@ -38,7 +38,7 @@ type installedCmd struct {
 func (*installedCmd) Name() string     { return "installed" }
 func (*installedCmd) Synopsis() string { return "list installed packages" }
 func (*installedCmd) Usage() string {
-	return fmt.Sprintf(`%s installed [-info] [<initial>]:
+	return fmt.Sprintf(`%s installed [-info] [-files] [<initial>]:
 	List installed packages beginning with an initial string,
 	if no initial string is provided all installed packages will be listed.
 `, filepath.Base(os.Args[0]))
@@ -46,6 +46,7 @@ func (*installedCmd) Usage() string {
 
 func (cmd *installedCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&cmd.info, "info", false, "display package info")
+	f.BoolVar(&cmd.files, "files", false, "display package file list")
 }
 
 func (cmd *installedCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
@@ -88,11 +89,23 @@ func (cmd *installedCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interf
 		if strings.Contains(p, filter) {
 			exitCode = subcommands.ExitSuccess
 			pi := goolib.PkgNameSplit(p)
+
 			if cmd.info {
 				local(pi, *state)
 				continue
 			}
 			fmt.Println(" ", pi.Name+"."+pi.Arch+" "+pi.Ver)
+
+                        if cmd.files {
+                                ps, err := state.GetPackageState(pi)
+                                if err != nil {
+                                        logger.Errorf("Unable to get file list for package %q.", arg)
+                                        continue
+                                }
+                                for file := range ps.InstalledFiles {
+                                        fmt.Println("  -", file)
+                                }
+                        }
 		}
 	}
 	if exitCode != subcommands.ExitSuccess {

--- a/googet_installed.go
+++ b/googet_installed.go
@@ -32,7 +32,7 @@ import (
 )
 
 type installedCmd struct {
-	info bool
+	info  bool
 	files bool
 }
 
@@ -97,16 +97,19 @@ func (cmd *installedCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interf
 			}
 			fmt.Println(" ", pi.Name+"."+pi.Arch+" "+pi.Ver)
 
-                        if cmd.files {
-                                ps, err := state.GetPackageState(pi)
-                                if err != nil {
-                                        logger.Errorf("Unable to get file list for package %q.", p)
-                                        continue
-                                }
-                                for file := range ps.InstalledFiles {
-                                        fmt.Println("  -", file)
-                                }
-                        }
+			if cmd.files {
+				ps, err := state.GetPackageState(pi)
+				if err != nil {
+					logger.Errorf("Unable to get file list for package %q.", p)
+					continue
+				}
+				if len(ps.InstalledFiles) == 0 {
+					fmt.Println("  - No files directly managed by GooGet.")
+				}
+				for file := range ps.InstalledFiles {
+					fmt.Println("  -", file)
+				}
+			}
 		}
 	}
 	if exitCode != subcommands.ExitSuccess {

--- a/googet_installed.go
+++ b/googet_installed.go
@@ -33,6 +33,7 @@ import (
 
 type installedCmd struct {
 	info bool
+	files bool
 }
 
 func (*installedCmd) Name() string     { return "installed" }
@@ -99,7 +100,7 @@ func (cmd *installedCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interf
                         if cmd.files {
                                 ps, err := state.GetPackageState(pi)
                                 if err != nil {
-                                        logger.Errorf("Unable to get file list for package %q.", arg)
+                                        logger.Errorf("Unable to get file list for package %q.", p)
                                         continue
                                 }
                                 for file := range ps.InstalledFiles {


### PR DESCRIPTION
The '-files' flag allows you to easily see the directly-managed list of files for a particular GooGet package or all of them. Great for quickly figuring out which package may contain a particular file. Outputs a message if no directly-managed files are found.