### PR TITLE
add config for windows tests in travis-ci

### DIFF
--- a/.travis.win_integration_test.ps1
+++ b/.travis.win_integration_test.ps1
@@ -1,0 +1,38 @@
+[CmdletBinding()]
+param (
+)
+
+# Build googet and Goo Package
+Write-Host 'Building googet'
+$build_proc = Start-Process go -ArgumentList @('run', 'goopack/goopack.go', './googet.goospec') -Wait -PassThru
+if ($build_proc.ExitCode -ne 0) {
+  Write-Error "Failed to build goopack got exit code $($build_proc.ExitCode), wanted 0"
+  exit $build_proc.ExitCode
+}
+# Determine output goo pack
+$goo = Get-ChildItem .\ | Where-Object {$_.Name -like '*.goo'}
+Write-Host "Found built goopack at $($goo.FullName)"
+
+# Setup Environment
+$goo_root = $env:ProgramData + '\Googet'
+if (!(Test-Path $goo_root)) {
+  New-Item -ItemType Directory -Path $goo_root
+}
+
+# Install googet
+Write-Host "Attempting to use googet to install $($goo.FullName)"
+$install_proc = Start-Process .\googet.exe -ArgumentList @('--noconfirm', "--root=`"$goo_root`"", '--verbose', 'install', $goo.FullName) -NoNewWindow -Wait -PassThru
+if ($install_proc.ExitCode -ne 0) {
+  Write-Error "Googet install exited with $($install_proc.ExitCode); wanted 0"
+  exit $install_proc.ExitCode
+}
+Write-Host "Successfully installed $($goo.FullName)"
+
+# Remove googet
+Write-Host 'Attempting to use googet to remove googet'
+$remove_proc = Start-Process "$env:ProgramData\GooGet\googet.exe" -ArgumentList @('--noconfirm', '--verbose', 'remove', 'googet') -NoNewWindow -Wait -PassThru
+if ($remove_proc.ExitCode -ne 0) {
+  Write-Error "Googet remove exited with $($remove_proc.ExitCode); wanted 0"
+  exit $remove_proc.ExitCode
+}
+Write-Host 'Successfully removed googet'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ matrix:
   include:
     - os: linux
       dist: trusty
+      sudo: false
     - os: windows
     
 language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
-dist: trusty
-sudo: false
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+    - os: windows
+    
 language: go
 go: stable 
 script:
   - go vet $(go list ./... | grep -v /vendor/)
-  - ./.travis.gofmt.sh
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./.travis.gofmt.sh; fi # gofmt throws errors about line endings on windows; only run gofmt on *nix
   - go test -v -race $(go list ./... | grep -v /vendor/)
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then powershell -ExecutionPolicy Bypass -File ./.travis.win_integration_test.ps1; fi # windows integration tests

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This is not an official Google product.
 
 ## Build
 
-Run build.ps1/build.sh to build GooGet for Windows. To package googet run
+To build and package googet run
 
 ```
 go run goopack/goopack.go googet.goospec
 ```
 
-This will result in googet.x86_64.VERSION.goo which can be installed on a 
+This will result in googet.exe and googet.x86_64.VERSION.goo which can be installed on a 
 machine with the `googet install` command (assuming googet is already 
 installed).
 

--- a/googet.goospec
+++ b/googet.goospec
@@ -59,8 +59,8 @@
       ]
   }],
   "build": {
-    "windows": "go",
-    "windowsArgs": ["build", "-ldflags='-X main.version={{$version}}'"],
+    "windows":  "c:/Windows/System32/cmd.exe",
+    "windowsArgs": ["/c", "go build -ldflags=-X=main.version={{$version}} -o googet.exe"],
     "linux": "/bin/bash",
     "linuxArgs": ["-c", "GOOS=windows go build -ldflags='-X main.version={{$version}}'"]
   }

--- a/goolib/goospec_test.go
+++ b/goolib/goospec_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -300,18 +301,34 @@ func TestNoPathTraversal(t *testing.T) {
   },
   "sources": []
 }`)
-	fail := []byte(`{
-  "name": "pkg",
-  "version": "1.2.3@4",
-  "arch": "noarch",
-  "releaseNotes": [],
-  "description": "blah blah",
-  "owners": "someone",
-  "install": {
-    "path": "/usr/bin/sudo"
-  },
-  "sources": []
-}`)
+	var fail []byte
+	if runtime.GOOS == "windows" {
+		fail = []byte(`{
+		"name": "pkg",
+		"version": "1.2.3@4",
+		"arch": "noarch",
+		"releaseNotes": [],
+		"description": "blah blah",
+		"owners": "someone",
+		"install": {
+			"path": "Z:\usr\bin\sudo"
+		},
+		"sources": []
+	}`)
+	} else {
+		fail = []byte(`{
+		"name": "pkg",
+		"version": "1.2.3@4",
+		"arch": "noarch",
+		"releaseNotes": [],
+		"description": "blah blah",
+		"owners": "someone",
+		"install": {
+			"path": "/usr/bin/sudo"
+		},
+		"sources": []
+	}`)
+	}
 	got, err := UnmarshalPackageSpec(c1)
 	if err != nil {
 		t.Fatalf("error running unmarshalGooSpec: %v", err)

--- a/goopack/goopack.go
+++ b/goopack/goopack.go
@@ -186,15 +186,15 @@ func glob(base string, includes, excludes []string) ([]string, error) {
 			out = append(out, filepath.Join(walk.parts[0]...))
 			continue
 		}
-		wd := filepath.Join(walk.parts[0][:walk.firstGlob]...)
+		wd := strings.Join(walk.parts[0][:walk.firstGlob], string(filepath.Separator))
 		files, err := walkDir(wd)
 		if err != nil {
 			return nil, fmt.Errorf("walking %s: %v", wd, err)
 		}
-
 		var walkincludes []string
 		for _, p := range walk.parts {
-			walkincludes = append(walkincludes, filepath.Join(p...))
+			path := filepath.Clean(strings.Join(p, string(filepath.Separator)))
+			walkincludes = append(walkincludes, path)
 		}
 		for _, file := range files {
 			keep, err := anyMatch(walkincludes, file)

--- a/goopack/goopack_test.go
+++ b/goopack/goopack_test.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/googet/v2/goolib"
@@ -87,7 +89,7 @@ func TestMapFiles(t *testing.T) {
 		t.Fatalf("error creating temp directory: %v", err)
 	}
 	defer oswrap.RemoveAll(tempDir)
-	wf1 := path.Join(tempDir, "globme.file")
+	wf1 := filepath.FromSlash(path.Join(tempDir, "globme.file"))
 	f, err := oswrap.Create(wf1)
 	if err != nil {
 		t.Fatalf("error creating test file: %v", err)
@@ -102,7 +104,7 @@ func TestMapFiles(t *testing.T) {
 	if err := oswrap.Mkdir(wd, 0755); err != nil {
 		t.Fatalf("error creating test directory: %v", err)
 	}
-	wf2 := path.Join(wd, "globmetoo.file")
+	wf2 := filepath.FromSlash(path.Join(wd, "globmetoo.file"))
 	f, err = oswrap.Create(wf2)
 	if err != nil {
 		t.Fatalf("error creating test file: %v", err)
@@ -126,7 +128,7 @@ func TestMapFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting file map: %v", err)
 	}
-	em := fileMap{"foo": []string{wf1}, "foo/globdir": []string{wf2}}
+	em := fileMap{"foo": []string{wf1}, strings.Join([]string{"foo", "globdir"}, string(filepath.Separator)): []string{wf2}}
 	if !reflect.DeepEqual(fm, em) {
 		t.Errorf("did not get expected package map: got %v, want %v", fm, em)
 	}

--- a/install/install_test.go
+++ b/install/install_test.go
@@ -136,6 +136,7 @@ func TestInstallPkg(t *testing.T) {
 		"is/quite/a/large/number/but/somehow/there/were/real/goo/packages" +
 		"which/exceeded/this/limit/hence/this/absurdly/long/string/in/" +
 		"this/unit/test")
+	dst = filepath.FromSlash(dst)
 
 	defer oswrap.RemoveAll(dst)
 

--- a/oswrap/oswrap.go
+++ b/oswrap/oswrap.go
@@ -26,6 +26,9 @@ func rootDir(name string) string {
 	if filepath.IsAbs(name) {
 		i++
 	}
+	if os.IsPathSeparator(name[i]) {
+		i++
+	}
 	for i < len(name) && !os.IsPathSeparator(name[i]) {
 		i++
 	}

--- a/oswrap/oswrap_test.go
+++ b/oswrap/oswrap_test.go
@@ -14,18 +14,26 @@ limitations under the License.
 package oswrap
 
 import (
+	"runtime"
 	"testing"
 )
 
 func TestRootDir(t *testing.T) {
 	var table = []struct {
-		path string
-		want string
+		path, want string
 	}{
-		{"/some/abs/path", "/some"},
-		{"some/rel/path", "some"},
+		{"/linux/abs/path", "/linux"},
+		{"linux/rel/path", "linux"},
 		{"/path", "/path"},
 	}
+
+	if runtime.GOOS == "windows" {
+		table = append(table, []struct{ path, want string }{
+			{`Z:\windows\abs\path`, `Z:\windows`},
+			{`\windows\rel\path`, `\windows`},
+		}...)
+	}
+
 	for _, tt := range table {
 		if got := rootDir(tt.path); got != tt.want {
 			t.Fatalf("rootDir did not return expected path, got: %q, want: %q ", got, tt.want)


### PR DESCRIPTION
Updated goospec to build under windows
Added travis-ci config to test under linux (trusty) and windows
Added logic to only run gofmt under linux (git messes with line endings and gofmt doesn't like that)
Added logic to build, install, and remove googet when running under windows
Updated build documentation

https://travis-ci.org/GitGerby/googet/builds/556570294
certain unit tests fail under Windows at the moment