### PR TITLE
Add a status code check for HTTP responses.

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -38,6 +38,10 @@ import (
 	"github.com/google/logger"
 )
 
+const (
+	httpOK = 200
+)
+
 // Package downloads a package from the given url,
 // the provided SHA256 checksum will be checked during download.
 func Package(ctx context.Context, pkgURL, dst, chksum, proxyServer string) error {
@@ -69,6 +73,9 @@ func packageHTTP(pkgURL, dst, chksum string, proxyServer string) error {
 		return err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != httpOK {
+		return fmt.Errorf("Invalid return code from server, got: %d, want: %d", resp.StatusCode, httpOK)
+	}
 
 	logger.Infof("Downloading %q", pkgURL)
 	return download(resp.Body, dst, chksum)

--- a/googet.goospec
+++ b/googet.goospec
@@ -1,4 +1,4 @@
-{{$version := "2.16.6@1" -}}
+{{$version := "2.16.7@1" -}}
 {
   "name": "googet",
   "version": "{{$version}}",
@@ -13,6 +13,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.16.7 - Add a status code check for HTTP responses.",
     "2.16.6 - Additional error logging in cleanOld.",
     "2.16.4 - Add flag to 'googet installed' to list directly-managed files.",
     "2.16.3 - Handle missing LocalPath state in the reinstall command",

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -34,6 +34,10 @@ import (
 	"github.com/google/logger"
 )
 
+const (
+	httpOK = 200
+)
+
 func extractVerify(r io.Reader, verify, dir string) error {
 	zr, err := gzip.NewReader(r)
 	if err != nil {
@@ -142,6 +146,9 @@ func Command(ctx context.Context, ps client.PackageState, proxyServer string) (b
 			return false, err
 		}
 		defer resp.Body.Close()
+		if resp.StatusCode != httpOK {
+			return false, fmt.Errorf("Invalid return code from server, got: %d, want: %d", resp.StatusCode, httpOK)
+		}
 		r = resp.Body
 	}
 	if err := extractVerify(r, ps.PackageSpec.Verify.Path, dir); err != nil {


### PR DESCRIPTION
The download and verify subcommands are failing to check the server response for non-successful status codes. This can lead to files being written containing the contents of an error page rather than the expected file content.

Fixes #72 