### PR TITLE
Update path to lock file

### DIFF
--- a/googet.go
+++ b/googet.go
@@ -58,6 +58,7 @@ var (
 	archs          []string
 	proxyServer    string
 	allowUnsafeURL bool
+	lockFile string
 )
 
 type packageMap map[string]string

--- a/googet.go
+++ b/googet.go
@@ -397,7 +397,7 @@ func runDeferredFuncs() {
 	}
 }
 
-func obtainLock() error {
+func obtainLock(lockFile string) error {
 	err := os.MkdirAll(filepath.Dir(lockFile), 0755)
 	if err != nil && !os.IsExist(err) {
 		return err
@@ -478,7 +478,8 @@ func main() {
 		logger.Fatalln("Error setting up root directory:", err)
 	}
 
-	if err := obtainLock(); err != nil {
+	lockFile := rootDir + "\\googet.lock"
+	if err := obtainLock(lockFile); err != nil {
 		logger.Fatalf("Cannot obtain GooGet lock, error: %v", err)
 	}
 	readConf(filepath.Join(rootDir, confFile))

--- a/googet.go
+++ b/googet.go
@@ -58,7 +58,7 @@ var (
 	archs          []string
 	proxyServer    string
 	allowUnsafeURL bool
-	lockFile string
+	lockFile       string
 )
 
 type packageMap map[string]string

--- a/googet.go
+++ b/googet.go
@@ -479,7 +479,7 @@ func main() {
 		logger.Fatalln("Error setting up root directory:", err)
 	}
 
-	lockFile := filepath.Join(rootDir, "googet.lock")
+	lockFile = filepath.Join(rootDir, "googet.lock")
 	if err := obtainLock(lockFile); err != nil {
 		logger.Fatalf("Cannot obtain GooGet lock, error: %v", err)
 	}

--- a/googet.go
+++ b/googet.go
@@ -478,7 +478,7 @@ func main() {
 		logger.Fatalln("Error setting up root directory:", err)
 	}
 
-	lockFile := rootDir + "\\googet.lock"
+	lockFile := filepath.Join(rootDir, "googet.lock")
 	if err := obtainLock(lockFile); err != nil {
 		logger.Fatalf("Cannot obtain GooGet lock, error: %v", err)
 	}

--- a/googet.goospec
+++ b/googet.goospec
@@ -1,4 +1,4 @@
-{{$version := "2.17.0@1" -}}
+{{$version := "2.17.1@1" -}}
 {
   "name": "googet",
   "version": "{{$version}}",

--- a/googet.goospec
+++ b/googet.goospec
@@ -13,6 +13,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.17.1 - Use an environment variable in the path to GooGet's lock file.",
     "2.17.0 - Update lock functionality.",
     "2.16.7 - Add a status code check for HTTP responses.",
     "2.16.6 - Additional error logging in cleanOld.",

--- a/googet.goospec
+++ b/googet.goospec
@@ -13,7 +13,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
-    "2.17.1 - Use an environment variable in the path to GooGet's lock file.",
+    "2.17.1 - Use the root directory to reference GooGet's lock file.",
     "2.17.0 - Update lock functionality.",
     "2.16.7 - Add a status code check for HTTP responses.",
     "2.16.6 - Additional error logging in cleanOld.",

--- a/lock_linux.go
+++ b/lock_linux.go
@@ -19,8 +19,6 @@ import (
 	"syscall"
 )
 
-const lockFile = "/run/lock/googet.lock"
-
 func lock(f *os.File) error {
 	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
 		return err

--- a/lock_windows.go
+++ b/lock_windows.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	kernel32         = windows.NewLazySystemDLL("kernel32.dll")
-	lockFile         = os.Getenv("ProgramData") + "\\GooGet\\googet.lock"
+	lockFile         = rootDir + "\\googet.lock"
 	procLockFileEx   = kernel32.NewProc("LockFileEx")
 	procUnlockFileEx = kernel32.NewProc("UnlockFileEx")
 )

--- a/lock_windows.go
+++ b/lock_windows.go
@@ -25,7 +25,6 @@ import (
 
 var (
 	kernel32         = windows.NewLazySystemDLL("kernel32.dll")
-	lockFile         = rootDir + "\\googet.lock"
 	procLockFileEx   = kernel32.NewProc("LockFileEx")
 	procUnlockFileEx = kernel32.NewProc("UnlockFileEx")
 )

--- a/lock_windows.go
+++ b/lock_windows.go
@@ -25,13 +25,12 @@ import (
 
 var (
 	kernel32         = windows.NewLazySystemDLL("kernel32.dll")
+	lockFile         = os.Getenv("ProgramData") + "\\GooGet\\googet.lock"
 	procLockFileEx   = kernel32.NewProc("LockFileEx")
 	procUnlockFileEx = kernel32.NewProc("UnlockFileEx")
 )
 
 const (
-	lockFile = "C:/ProgramData/GooGet/googet.lock"
-
 	// https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-lockfileex
 	LOCKFILE_EXCLUSIVE_LOCK   = 2
 	LOCKFILE_FAIL_IMMEDIATELY = 1


### PR DESCRIPTION
* Use the rootDir flag in the path to GooGet's lock file, to avoid assuming that it will be located on C:\ 