### PR TITLE
Disable file lock during listrepo operation

### DIFF
--- a/googet.go
+++ b/googet.go
@@ -466,7 +466,7 @@ func main() {
 	cmdr.ImportantFlag("verbose")
 	cmdr.ImportantFlag("noconfirm")
 
-	nonLockingCommands := []string{"help", "commands", "flags"}
+	nonLockingCommands := []string{"help", "commands", "flags", "listrepos"}
 	if ggFlags.NArg() == 0 || goolib.ContainsString(ggFlags.Args()[0], nonLockingCommands) {
 		os.Exit(int(cmdr.Execute(context.Background())))
 	}


### PR DESCRIPTION
This is intended to allow listrepo operations without elevated rights