### PR TITLE
Removing error message in x86 detection 

### DIFF
--- a/googet.goospec
+++ b/googet.goospec
@@ -1,4 +1,4 @@
-{{$version := "2.17.3@1" -}}
+{{$version := "2.17.4@1" -}}
 {
   "name": "googet",
   "version": "{{$version}}",
@@ -13,6 +13,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.17.4 - Removing x86 detection error message",
     "2.17.3 - Retry once on any Get failure",
     "2.17.2 - Add Source field in GooGet Spec",
     "2.17.1 - Use the root directory to reference GooGet's lock file.",

--- a/system/system_windows.go
+++ b/system/system_windows.go
@@ -176,7 +176,6 @@ func InstallableArchs() ([]string, error) {
 		// Check if this is indeed a 32bit system.
 		aw, err := width()
 		if err != nil {
-			logger.Errorf("Error getting AddressWidth: %v", err)
 			return []string{"noarch", "x86_32"}, nil
 		}
 		if int(aw) == 32 {


### PR DESCRIPTION
Removing error message as it is called before logging has been initialized and updating package version.