### PR TITLE
Use strings.EqualFold for efficient string comparison.

### DIFF
--- a/googet.goospec
+++ b/googet.goospec
@@ -1,4 +1,4 @@
-{{$version := "2.17.4@1" -}}
+{{$version := "2.17.5@1" -}}
 {
   "name": "googet",
   "version": "{{$version}}",
@@ -13,6 +13,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.17.5 - Use strings.EqualFold for string comparison",
     "2.17.4 - Removing x86 detection error message",
     "2.17.3 - Retry once on any Get failure",
     "2.17.2 - Add Source field in GooGet Spec",

--- a/googet_rmrepo.go
+++ b/googet_rmrepo.go
@@ -61,7 +61,7 @@ func (cmd *rmRepoCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	var foundRepo repoFile
 	for _, rf := range rfs {
 		for _, re := range rf.repoEntries {
-			if strings.ToLower(re.Name) == strings.ToLower(name) {
+			if strings.EqualFold(re.Name, name) {
 				foundRepo = rf
 				break
 			}
@@ -75,7 +75,7 @@ func (cmd *rmRepoCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 
 	var res []repoEntry
 	for _, re := range foundRepo.repoEntries {
-		if strings.ToLower(re.Name) != strings.ToLower(name) {
+		if strings.EqualFold(re.Name, name) {
 			res = append(res, re)
 		}
 	}


### PR DESCRIPTION
Addresses static check error SA6005: https://staticcheck.io/docs/checks#SA6005