### PR TITLE
Google oauth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ archs: [noarch, x86_64]
 cachelife: 10m
 ```
 
+## Repo file
+
+GooGet has the ability to use a repo file to change some repo specific settings.
+The file is named your-repo-name.repo by default. It can be used to set the
+source URL and indicate that the client should pass authorization headers in 
+requests to the source URL.
+
+```
+URL: https://foo.com/googet/bar
+  oauth: true
+```
+
 ## Google Cloud Storage as a back-end
 
 Googet supports using Google Cloud Storage as its server.

--- a/client/client.go
+++ b/client/client.go
@@ -34,6 +34,8 @@ import (
 	"github.com/google/googet/v2/goolib"
 	"github.com/google/googet/v2/oswrap"
 	"github.com/google/logger"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/googleapi"
 )
 
@@ -158,11 +160,13 @@ func decode(index io.ReadCloser, ct, url, cf string) ([]goolib.RepoSpec, error) 
 // if mtime is less than cacheLife.
 // Sucessfully unmarshalled contents will be written to a cache.
 func unmarshalRepoPackages(ctx context.Context, p, cacheDir string, cacheLife time.Duration, proxyServer string) ([]goolib.RepoSpec, error) {
-	cf := filepath.Join(cacheDir, fmt.Sprintf("%x.rs", sha256.Sum256([]byte(p))))
+	pName := strings.TrimPrefix(p, "oauth-")
+
+	cf := filepath.Join(cacheDir, fmt.Sprintf("%x.rs", sha256.Sum256([]byte(pName))))
 
 	fi, err := oswrap.Stat(cf)
 	if err == nil && time.Since(fi.ModTime()) < cacheLife {
-		logger.Infof("Using cached repo content for %s.", p)
+		logger.Infof("Using cached repo content for %s.", pName)
 		f, err := oswrap.Open(cf)
 		if err != nil {
 			return nil, err
@@ -179,18 +183,27 @@ func unmarshalRepoPackages(ctx context.Context, p, cacheDir string, cacheLife ti
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
-	logger.Infof("Fetching repo content for %s, cache either doesn't exist or is older than %v", p, cacheLife)
+	logger.Infof("Fetching repo content for %s, cache either doesn't exist or is older than %v", pName, cacheLife)
 
-	isGCSURL, bucket, object := goolib.SplitGCSUrl(p)
+	isGCSURL, bucket, object := goolib.SplitGCSUrl(pName)
 	if isGCSURL {
-		return unmarshalRepoPackagesGCS(ctx, bucket, object, p, cf, proxyServer)
+		return unmarshalRepoPackagesGCS(ctx, bucket, object, pName, cf, proxyServer)
 	}
-	return unmarshalRepoPackagesHTTP(p, cf, proxyServer)
+	return unmarshalRepoPackagesHTTP(ctx, p, cf, proxyServer)
 }
 
 // Get gets a url using an optional proxy server, retrying once on any error.
-func Get(path, proxyServer string) (*http.Response, error) {
-	httpClient := http.DefaultClient
+func Get(ctx context.Context, path, proxyServer string, useOauth bool) (*http.Response, error) {
+	var httpClient *http.Client
+	if useOauth {
+		creds, err := google.FindDefaultCredentials(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to obtain creds: %v", err)
+		}
+		httpClient = oauth2.NewClient(ctx, creds.TokenSource)
+	} else {
+		httpClient = http.DefaultClient
+	}
 	proxy := http.ProxyFromEnvironment
 	if proxyServer != "" {
 		proxyURL, err := url.Parse(proxyServer)
@@ -220,11 +233,12 @@ func Get(path, proxyServer string) (*http.Response, error) {
 	return httpClient.Get(path)
 }
 
-func unmarshalRepoPackagesHTTP(repoURL string, cf string, proxyServer string) ([]goolib.RepoSpec, error) {
+func unmarshalRepoPackagesHTTP(ctx context.Context, repoURL string, cf string, proxyServer string) ([]goolib.RepoSpec, error) {
 	indexURL := repoURL + "/index.gz"
 	ct := "application/x-gzip"
 	logger.Infof("Fetching %q", indexURL)
-	res, err := Get(indexURL, proxyServer)
+	useOauth := strings.HasPrefix(repoURL, "oauth-")
+	res, err := Get(ctx, indexURL, proxyServer, useOauth)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +248,7 @@ func unmarshalRepoPackagesHTTP(repoURL string, cf string, proxyServer string) ([
 		indexURL = repoURL + "/index"
 		ct = "application/json"
 		logger.Infof("Fetching %q", indexURL)
-		res, err = Get(indexURL, proxyServer)
+		res, err = Get(ctx, indexURL, proxyServer, useOauth)
 		if err != nil {
 			return nil, err
 		}

--- a/download/download.go
+++ b/download/download.go
@@ -53,12 +53,13 @@ func Package(ctx context.Context, pkgURL, dst, chksum, proxyServer string) error
 		return packageGCS(ctx, bucket, object, dst, chksum, "")
 	}
 
-	return packageHTTP(pkgURL, dst, chksum, proxyServer)
+	return packageHTTP(ctx, pkgURL, dst, chksum, proxyServer)
 }
 
 // Downloads a package from an HTTP(s) server
-func packageHTTP(pkgURL, dst, chksum string, proxyServer string) error {
-	resp, err := client.Get(pkgURL, proxyServer)
+func packageHTTP(ctx context.Context, pkgURL, dst, chksum string, proxyServer string) error {
+	useOauth := strings.HasPrefix(pkgURL, "oauth-")
+	resp, err := client.Get(ctx, pkgURL, proxyServer, useOauth)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4
 	golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449 // indirect
 	golang.org/x/net v0.0.0-20201029221708-28c70e62bb1d // indirect
+	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 // indirect
 	golang.org/x/sys v0.0.0-20201029080932-201ba4db2418
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/tools v0.0.0-20201030204249-4fc0492b8eca // indirect

--- a/googet_test.go
+++ b/googet_test.go
@@ -58,6 +58,10 @@ func TestRepoList(t *testing.T) {
 		{[]byte("- url: " + testRepo + "\n\n- URL: " + testHTTPRepo), []string{testRepo, testHTTPRepo}, true},
 		{[]byte("- url: " + testRepo + "\n\n- URL: " + testRepo), []string{testRepo, testRepo}, false},
 		{[]byte("- url: " + testRepo + "\n\n- url: " + testRepo), []string{testRepo, testRepo}, false},
+		// Should contain oauth- prefix
+		{[]byte("- url: " + testRepo + "\n  oauth: true"), []string{"oauth-" + testRepo}, false},
+		// Should not contain oauth- prefix
+		{[]byte("- url: " + testRepo + "\n  oauth: false"), []string{testRepo}, false},
 	}
 
 	for i, tt := range repoTests {


### PR DESCRIPTION
Support for passing Oauth headers via the google Oauth library. Repositories are configured for oauth by adding an "oauth" line to their repo file. For example:

```
URL: https://foo.com/googet/bar
  oauth: true
``` 

cc @adjackura 