### PR TITLE
Bugfix googet verify

### DIFF
--- a/googet.goospec
+++ b/googet.goospec
@@ -1,4 +1,4 @@
-{{$version := "2.18.4@0" -}}
+{{$version := "2.18.5@0" -}}
 {
   "name": "googet",
   "version": "{{$version}}",
@@ -15,6 +15,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.18.5 - Fixed 'googet verify' bug that caused failure where it should succeed.",
     "2.18.4 - Fixed rmrepo bug. All other repos from the repo file were removed.",
     "2.18.2 - Rename Oauth credential configuration and manually set Authorization header in requests.",
     "2.18.0 - Add support for passing Oauth credentials with GooGet requests.",

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -89,7 +89,11 @@ func Files(ps client.PackageState) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		fstat, _ := os.Stat(file)
+		fstat, err := os.Stat(file)
+		if err != nil {
+			logger.Errorf("%q: Error accessing file info for %q: %w", pkg, file, err)
+			return false, nil
+		}
 		// Only calculate/ check the checksum for file, not folder.
 		if fstat.IsDir() {
 			continue

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -91,8 +91,7 @@ func Files(ps client.PackageState) (bool, error) {
 		}
 		fstat, err := os.Stat(file)
 		if err != nil {
-			logger.Errorf("%q: Error accessing file info for %q: %w", pkg, file, err)
-			return false, nil
+			return false, err
 		}
 		// Only calculate/ check the checksum for file, not folder.
 		if fstat.IsDir() {

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -89,6 +89,11 @@ func Files(ps client.PackageState) (bool, error) {
 		if err != nil {
 			return false, err
 		}
+		fstat, _ := os.Stat(file)
+		// Only calculate/ check the checksum for file, not folder.
+		if fstat.IsDir() {
+			continue
+		}
 		chksm := goolib.Checksum(f)
 		f.Close()
 		if wantChksm != chksm {

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -22,7 +22,14 @@ import (
 	"github.com/google/googet/v2/client"
 	"github.com/google/googet/v2/goolib"
 	"github.com/google/googet/v2/oswrap"
+	"github.com/google/logger"
 )
+
+func TestMain(m *testing.M) {
+	// Initialize the logger.
+	logger.Init("test", false, false, ioutil.Discard)
+	os.Exit(m.Run())
+}
 
 func TestFiles(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "")
@@ -50,7 +57,7 @@ func TestFiles(t *testing.T) {
 		{"no files found", client.PackageState{InstalledFiles: map[string]string{"foo": "bar"}, PackageSpec: &goolib.PkgSpec{Name: "foo", Arch: "noarch", Version: "1.0.0@1"}}, false},
 		{"file checksum does not match", client.PackageState{InstalledFiles: map[string]string{testFile: "bar"}, PackageSpec: &goolib.PkgSpec{Name: "foo", Arch: "noarch", Version: "1.0.0@1"}}, false},
 		{"file checksum matches", client.PackageState{InstalledFiles: map[string]string{testFile: chksm}, PackageSpec: &goolib.PkgSpec{Name: "foo", Arch: "noarch", Version: "1.0.0@1"}}, true},
-		{"should skip folder", client.PackageState{InstalledFiles: map[string]string{tempDir: "",testFile: chksm}, PackageSpec: &goolib.PkgSpec{Name: "foo", Arch: "noarch", Version: "1.0.0@1"}}, true},
+		{"should skip folder", client.PackageState{InstalledFiles: map[string]string{tempDir: "", testFile: chksm}, PackageSpec: &goolib.PkgSpec{Name: "foo", Arch: "noarch", Version: "1.0.0@1"}}, true},
 	}
 	for _, tt := range table {
 		verify, err := Files(tt.ps)

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -50,6 +50,7 @@ func TestFiles(t *testing.T) {
 		{"no files found", client.PackageState{InstalledFiles: map[string]string{"foo": "bar"}, PackageSpec: &goolib.PkgSpec{Name: "foo", Arch: "noarch", Version: "1.0.0@1"}}, false},
 		{"file checksum does not match", client.PackageState{InstalledFiles: map[string]string{testFile: "bar"}, PackageSpec: &goolib.PkgSpec{Name: "foo", Arch: "noarch", Version: "1.0.0@1"}}, false},
 		{"file checksum matches", client.PackageState{InstalledFiles: map[string]string{testFile: chksm}, PackageSpec: &goolib.PkgSpec{Name: "foo", Arch: "noarch", Version: "1.0.0@1"}}, true},
+		{"should skip folder", client.PackageState{InstalledFiles: map[string]string{tempDir: "",testFile: chksm}, PackageSpec: &goolib.PkgSpec{Name: "foo", Arch: "noarch", Version: "1.0.0@1"}}, true},
 	}
 	for _, tt := range table {
 		verify, err := Files(tt.ps)


### PR DESCRIPTION
## Summary

### What matter does the PR address?

This PR addresses the `googet verify` failure message which the verify should pass. Please also refer to internal bug.

### How does PR address the matter?

The `googet verify` compares the checksums between

- the file checksum information within the googet state file, and
- calculated checksum of current file(s) on disk

As the googet state file only keep file checksum, and not folder. This PR ensures verify only checks for file checksum.

### What is the Test Result?

The `go test` result is `PASS`. Summarized result:

```
> go test  -v
=== RUN   TestFiles
Running file verification for foo.noarch.1.0.0@1...
<...log truncated...>
--- PASS: TestFiles (0.03s)
PASS
ok      github.com/google/googet/v2/verify      1.171s
```


Thank you,

Lawrence