### PR TITLE
update go.mod to 1.16

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,12 +16,12 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.15
+        go-version: 1.16.x
 
     - name: Format
       run: |
@@ -44,12 +44,12 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.15
+        go-version: 1.16.x
 
     - name: Vet
       run: go vet ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/googet/v2
 
-go 1.13
+go 1.16
 
 require (
 	cloud.google.com/go/storage v1.15.0

--- a/oswrap/oswrap_unix.go
+++ b/oswrap/oswrap_unix.go
@@ -1,4 +1,5 @@
-//+build linux darwin
+//go:build linux || darwin
+// +build linux darwin
 
 /*
 Copyright 2016 Google Inc. All Rights Reserved.

--- a/oswrap/oswrap_windows.go
+++ b/oswrap/oswrap_windows.go
@@ -1,4 +1,5 @@
-//+build windows
+//go:build windows
+// +build windows
 
 /*
 Copyright 2016 Google Inc. All Rights Reserved.

--- a/system/system_linux.go
+++ b/system/system_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/system/system_windows.go
+++ b/system/system_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
Update go.mod for googet to Go 1.16.

- Update go.mod to 1.16
- Update Github workflows as well
- Run gofmt as needed for workflows to pass