### PR TITLE
add installdate metadata

### DIFF
--- a/googet.goospec
+++ b/googet.goospec
@@ -15,6 +15,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "2.20.0 - Add installdate metadata to registry key for consumption by external tools.",
     "2.19.0 - Updated to Go 1.19.",
     "2.18.5 - Fixed 'googet verify' bug that caused failure where it should succeed.",
     "2.18.4 - Fixed rmrepo bug. All other repos from the repo file were removed.",

--- a/system/system_windows.go
+++ b/system/system_windows.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/StackExchange/wmi"
 	"github.com/google/googet/v2/goolib"
@@ -52,6 +53,7 @@ func addUninstallEntry(dir string, ps *goolib.PkgSpec) error {
 		{"InstallLocation", dir},
 		{"DisplayVersion", ps.Version},
 		{"DisplayName", "GooGet - " + ps.Name},
+		{"InstallDate", time.Now().Format("20060102")},
 	}
 	for _, re := range table {
 		if err := k.SetStringValue(re.name, re.value); err != nil {


### PR DESCRIPTION
write install date to registry to allow tools like osquery to determine when a goo package was installed.