### PR TITLE
Allow using semantic names for priority levels.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -33,6 +33,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/google/googet/v2/goolib"
 	"github.com/google/googet/v2/oswrap"
+	"github.com/google/googet/v2/priority"
 	"github.com/google/logger"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/googleapi"
@@ -94,7 +95,7 @@ func (ps *PackageState) Match(pi goolib.PackageInfo) bool {
 
 // Repo represents a single downloaded repo.
 type Repo struct {
-	Priority int
+	Priority priority.Value
 	Packages []goolib.RepoSpec
 }
 
@@ -102,7 +103,7 @@ type Repo struct {
 type RepoMap map[string]Repo
 
 // AvailableVersions builds a RepoMap from a list of sources.
-func AvailableVersions(ctx context.Context, srcs map[string]int, cacheDir string, cacheLife time.Duration, proxyServer string) RepoMap {
+func AvailableVersions(ctx context.Context, srcs map[string]priority.Value, cacheDir string, cacheLife time.Duration, proxyServer string) RepoMap {
 	rm := make(RepoMap)
 	for r, pri := range srcs {
 		rf, err := unmarshalRepoPackages(ctx, r, cacheDir, cacheLife, proxyServer)
@@ -329,7 +330,7 @@ func FindRepoSpec(pi goolib.PackageInfo, repo Repo) (goolib.RepoSpec, error) {
 // package specs in psm.
 func latest(psm map[string][]*goolib.PkgSpec, rm RepoMap) (string, string) {
 	var ver, repo string
-	var pri int
+	var pri priority.Value
 	for r, pl := range psm {
 		for _, pkg := range pl {
 			q := rm[r].Priority

--- a/googet_update.go
+++ b/googet_update.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/googet/v2/client"
 	"github.com/google/googet/v2/goolib"
 	"github.com/google/googet/v2/install"
+	"github.com/google/googet/v2/priority"
 	"github.com/google/logger"
 	"github.com/google/subcommands"
 )
@@ -112,7 +113,7 @@ func updates(pm packageMap, rm client.RepoMap) []goolib.PackageInfo {
 			logger.Info(err)
 			continue
 		}
-		c, err := goolib.ComparePriorityVersion(rm[r].Priority, v, defaultPriority, ver)
+		c, err := goolib.ComparePriorityVersion(rm[r].Priority, v, priority.Default, ver)
 		if err != nil {
 			logger.Error(err)
 			continue

--- a/goolib/goospec.go
+++ b/goolib/goospec.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/google/googet/v2/priority"
 )
 
 type build struct {
@@ -170,7 +171,7 @@ func fixVer(ver string) string {
 }
 
 // ComparePriorityVersion compares (p1, v1) to (p2, v2) as priority-version tuples.
-func ComparePriorityVersion(p1 int, v1 string, p2 int, v2 string) (int, error) {
+func ComparePriorityVersion(p1 priority.Value, v1 string, p2 priority.Value, v2 string) (int, error) {
 	if p1 < p2 {
 		return -1, nil
 	}

--- a/goolib/goospec_test.go
+++ b/goolib/goospec_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
+	"github.com/google/googet/v2/priority"
 )
 
 func mkVer(sem string, rel int64) Version {
@@ -208,24 +209,24 @@ func TestBadCompare(t *testing.T) {
 func TestComparePriorityVersion(t *testing.T) {
 	for _, tc := range []struct {
 		desc string
-		p1   int
+		p1   priority.Value
 		v1   string
-		p2   int
+		p2   priority.Value
 		v2   string
 		want int
 	}{
-		{"same priority, same version, lesser release", 500, "1.2.3@1", 500, "1.2.3@2", -1},
-		{"same priority lesser version", 500, "1.2.3@1", 500, "1.2.4@2", -1},
-		{"same priority, greater version", 500, "1.2.4@1", 500, "1.2.3@2", 1},
-		{"same priority, same version", 500, "1.2.3", 500, "1.2.3", 0},
-		{"lesser priority, same version, lesser release", 500, "1.2.3@1", 1000, "1.2.3@2", -1},
-		{"lesser priority, lesser version", 500, "1.2.3@1", 1000, "1.2.4@2", -1},
-		{"lesser priority, greater version", 500, "1.2.4@1", 1000, "1.2.3@2", -1},
-		{"lesser priority, same version", 500, "1.2.3", 1000, "1.2.3", -1},
-		{"greater priority, same version, lesser release", 1000, "1.2.3@1", 500, "1.2.3@2", 1},
-		{"greater priority, lesser version", 1000, "1.2.3@1", 500, "1.2.4@2", 1},
-		{"greater priority, greater version", 1000, "1.2.4@1", 500, "1.2.3@2", 1},
-		{"greater priority, same version", 1000, "1.2.3", 500, "1.2.3", 1},
+		{"same priority, same version, lesser release", priority.Value(500), "1.2.3@1", priority.Value(500), "1.2.3@2", -1},
+		{"same priority lesser version", priority.Value(500), "1.2.3@1", priority.Value(500), "1.2.4@2", -1},
+		{"same priority, greater version", priority.Value(500), "1.2.4@1", priority.Value(500), "1.2.3@2", 1},
+		{"same priority, same version", priority.Value(500), "1.2.3", priority.Value(500), "1.2.3", 0},
+		{"lesser priority, same version, lesser release", priority.Value(500), "1.2.3@1", priority.Value(1000), "1.2.3@2", -1},
+		{"lesser priority, lesser version", priority.Value(500), "1.2.3@1", priority.Value(1000), "1.2.4@2", -1},
+		{"lesser priority, greater version", priority.Value(500), "1.2.4@1", priority.Value(1000), "1.2.3@2", -1},
+		{"lesser priority, same version", priority.Value(500), "1.2.3", priority.Value(1000), "1.2.3", -1},
+		{"greater priority, same version, lesser release", priority.Value(1000), "1.2.3@1", priority.Value(500), "1.2.3@2", 1},
+		{"greater priority, lesser version", priority.Value(1000), "1.2.3@1", priority.Value(500), "1.2.4@2", 1},
+		{"greater priority, greater version", priority.Value(1000), "1.2.4@1", priority.Value(500), "1.2.3@2", 1},
+		{"greater priority, same version", priority.Value(1000), "1.2.3", priority.Value(500), "1.2.3", 1},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			if got, err := ComparePriorityVersion(tc.p1, tc.v1, tc.p2, tc.v2); err != nil {

--- a/priority/priority.go
+++ b/priority/priority.go
@@ -1,0 +1,38 @@
+// Package priority provides standard priority levels.
+package priority
+
+import "strconv"
+
+// Value is an integer priority associated with a repo.
+type Value int
+
+const (
+	// None is an unspecified priority level.
+	None Value = 0
+	// Default is the default priority level for everything.
+	Default Value = 500
+	// Canary is the priority level for canary repos.
+	Canary Value = 1300
+	// Pin is the priority level for user-pinned repos.
+	Pin Value = 1400
+	// Rollback is the priority level for rollback repos.
+	Rollback Value = 1500
+)
+
+// priorityNameToValue maps semantic priority names to their integer values.
+var priorityNameToValue = map[string]Value{
+	"default":  Default,
+	"canary":   Canary,
+	"pin":      Pin,
+	"rollback": Rollback,
+}
+
+// FromString converts the string s into a priority Value, where s represents
+// either a semantic priority name or an integer.
+func FromString(s string) (Value, error) {
+	if v, ok := priorityNameToValue[s]; ok {
+		return v, nil
+	}
+	i, err := strconv.Atoi(s)
+	return Value(i), err
+}

--- a/priority/priority_test.go
+++ b/priority/priority_test.go
@@ -1,0 +1,31 @@
+package priority
+
+import (
+	"testing"
+)
+
+func TestFromString(t *testing.T) {
+	for _, tc := range []struct {
+		s       string
+		want    Value
+		wantErr bool
+	}{
+		{s: "default", want: Default},
+		{s: "canary", want: Canary},
+		{s: "pin", want: Pin},
+		{s: "rollback", want: Rollback},
+		{s: "100", want: Value(100)},
+		{s: "bad", wantErr: true},
+	} {
+		t.Run(tc.s, func(t *testing.T) {
+			got, err := FromString(tc.s)
+			if err != nil && !tc.wantErr {
+				t.Errorf("FromString(%s) failed: %v", tc.s, err)
+			} else if err == nil && tc.wantErr {
+				t.Errorf("FromString(%s) got nil error, wanted non-nil", tc.s)
+			} else if got != tc.want {
+				t.Errorf("FromString(%s) got: %v, want: %v", tc.s, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This maps certain strings like "rollback" or "canary" to a standard integer priority so that priorities in repo configs may be specified with these strings.