### PR TITLE
Add arm64 arch support to googet.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -132,12 +132,13 @@ func TestFindRepoLatest(t *testing.T) {
 		{
 			desc:  "name and arch",
 			pi:    goolib.PackageInfo{Name: "foo_pkg", Arch: "noarch"},
-			archs: []string{"noarch", "x86_64"},
+			archs: []string{"noarch", "x86_64", "arm64"},
 			rm: RepoMap{
 				"foo_repo": Repo{Packages: []goolib.RepoSpec{
 					{PackageSpec: &goolib.PkgSpec{Name: "foo_pkg", Version: "1.2.3@4", Arch: "noarch"}},
 					{PackageSpec: &goolib.PkgSpec{Name: "foo_pkg", Version: "2.0.0@1", Arch: "x86_64"}},
 					{PackageSpec: &goolib.PkgSpec{Name: "foo_pkg", Version: "1.0.0@1", Arch: "noarch"}},
+					{PackageSpec: &goolib.PkgSpec{Name: "foo_pkg", Version: "3.0.0@1", Arch: "arm64"}},
 					{PackageSpec: &goolib.PkgSpec{Name: "bar_pkg", Version: "2.3.0@1", Arch: "noarch"}},
 				}},
 			},
@@ -148,12 +149,13 @@ func TestFindRepoLatest(t *testing.T) {
 		{
 			desc:  "name only",
 			pi:    goolib.PackageInfo{Name: "foo_pkg"},
-			archs: []string{"noarch", "x86_64"},
+			archs: []string{"noarch", "x86_64", "arm64"},
 			rm: RepoMap{
 				"foo_repo": Repo{Packages: []goolib.RepoSpec{
 					{PackageSpec: &goolib.PkgSpec{Name: "foo_pkg", Version: "1.2.3@4", Arch: "noarch"}},
 					{PackageSpec: &goolib.PkgSpec{Name: "foo_pkg", Version: "2.0.0@1", Arch: "x86_64"}},
 					{PackageSpec: &goolib.PkgSpec{Name: "foo_pkg", Version: "1.0.0@1", Arch: "noarch"}},
+					{PackageSpec: &goolib.PkgSpec{Name: "foo_pkg", Version: "3.0.0@1", Arch: "arm64"}},
 					{PackageSpec: &goolib.PkgSpec{Name: "bar_pkg", Version: "2.3.0@1", Arch: "noarch"}},
 				}},
 			},
@@ -164,7 +166,7 @@ func TestFindRepoLatest(t *testing.T) {
 		{
 			desc:  "specified arch not present",
 			pi:    goolib.PackageInfo{Name: "foo_pkg", Arch: "x86_64"},
-			archs: []string{"noarch", "x86_64"},
+			archs: []string{"noarch", "x86_64", "arm64"},
 			rm: RepoMap{
 				"foo_repo": Repo{Packages: []goolib.RepoSpec{
 					{PackageSpec: &goolib.PkgSpec{Name: "foo_pkg", Version: "1.2.3@4", Arch: "noarch"}},
@@ -177,7 +179,7 @@ func TestFindRepoLatest(t *testing.T) {
 		{
 			desc:  "multiple repos with same priority",
 			pi:    goolib.PackageInfo{Name: "foo_pkg", Arch: "noarch"},
-			archs: []string{"noarch", "x86_64"},
+			archs: []string{"noarch", "x86_64", "arm64"},
 			rm: RepoMap{
 				"foo_repo": Repo{
 					Priority: 500,
@@ -199,7 +201,7 @@ func TestFindRepoLatest(t *testing.T) {
 		{
 			desc:  "multiple repos with different priority",
 			pi:    goolib.PackageInfo{Name: "foo_pkg", Arch: "noarch"},
-			archs: []string{"noarch", "x86_64"},
+			archs: []string{"noarch", "x86_64", "arm64"},
 			rm: RepoMap{
 				"high_priority_repo": Repo{
 					Priority: 1500,

--- a/googet_test.go
+++ b/googet_test.go
@@ -128,7 +128,7 @@ func TestReadConf(t *testing.T) {
 		t.Fatalf("error creating conf file: %v", err)
 	}
 
-	content := []byte("archs: [noarch, x86_64]\ncachelife: 10m\nallowunsafeurl: true")
+	content := []byte("archs: [noarch, x86_64, arm64]\ncachelife: 10m\nallowunsafeurl: true")
 	if _, err := f.Write(content); err != nil {
 		t.Fatalf("error writing conf file: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestReadConf(t *testing.T) {
 
 	readConf(confPath)
 
-	ea := []string{"noarch", "x86_64"}
+	ea := []string{"noarch", "x86_64", "arm64"}
 	if !reflect.DeepEqual(archs, ea) {
 		t.Errorf("readConf did not create expected arch list, want: %s, got: %s", ea, archs)
 	}

--- a/goolib/goospec.go
+++ b/goolib/goospec.go
@@ -69,7 +69,7 @@ const (
 	maxTagValueSize = 1024 * 10 // 10k
 )
 
-var validArch = []string{"noarch", "x86_64", "x86_32", "arm"}
+var validArch = []string{"noarch", "x86_64", "x86_32", "arm", "arm64"}
 
 // PkgSpec is an individual package specification.
 type PkgSpec struct {

--- a/install/install_test.go
+++ b/install/install_test.go
@@ -59,6 +59,7 @@ func TestMinInstalled(t *testing.T) {
 		{"foo_pkg", "noarch", true},
 		{"foo_pkg", "", true},
 		{"foo_pkg", "x86_64", false},
+		{"foo_pkg", "arm64", false},
 		{"bar_pkg", "noarch", false},
 		{"baz_pkg", "noarch", false},
 	}

--- a/system/system_linux.go
+++ b/system/system_linux.go
@@ -72,5 +72,5 @@ func Uninstall(dir string, ps *goolib.PkgSpec) error {
 // InstallableArchs returns a slice of archs supported by this machine.
 func InstallableArchs() ([]string, error) {
 	// Just return all archs as Linux builds are currently just used for testing.
-	return []string{"noarch", "x86_64", "x86_32", "arm"}, nil
+	return []string{"noarch", "x86_64", "x86_32", "arm", "arm64"}, nil
 }

--- a/system/system_windows.go
+++ b/system/system_windows.go
@@ -301,6 +301,8 @@ func InstallableArchs() ([]string, error) {
 		return []string{"noarch", "x86_32", "x86_64"}, nil
 	case runtime.GOARCH == "arm":
 		return []string{"noarch", "arm"}, nil
+	case runtime.GOARCH == "arm64":
+		return []string{"noarch", "x86_32", "x86_64", "arm64"}, nil
 	default:
 		return nil, fmt.Errorf("runtime %s not supported", runtime.GOARCH)
 	}


### PR DESCRIPTION
Note that `arm64` allows for `x86[_64]` emulation while 32-bit ARM (`arm`) does not, hence the difference in `InstallableArchs()`.