### PR TITLE
Reuse the same HTTP client for all requests.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -268,7 +268,11 @@ func TestUnmarshalRepoPackagesJSON(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	got, err := unmarshalRepoPackages(context.Background(), ts.URL, tempDir, cacheLife, proxyServer)
+	d, err := NewDownloader(proxyServer)
+	if err != nil {
+		t.Fatalf("NewDownloader(%s): %v", proxyServer, err)
+	}
+	got, err := d.unmarshalRepoPackages(context.Background(), ts.URL, tempDir, cacheLife)
 	if err != nil {
 		t.Fatalf("Error running unmarshalRepoPackages: %v", err)
 	}
@@ -313,7 +317,11 @@ func TestUnmarshalRepoPackagesGzip(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	got, err := unmarshalRepoPackages(context.Background(), ts.URL, tempDir, cacheLife, proxyServer)
+	d, err := NewDownloader(proxyServer)
+	if err != nil {
+		t.Fatalf("NewDownloader(%s): %v", proxyServer, err)
+	}
+	got, err := d.unmarshalRepoPackages(context.Background(), ts.URL, tempDir, cacheLife)
 	if err != nil {
 		t.Fatalf("Error running unmarshalRepoPackages: %v", err)
 	}
@@ -351,7 +359,11 @@ func TestUnmarshalRepoPackagesCache(t *testing.T) {
 	}
 
 	// No http server as this should use the cached content.
-	got, err := unmarshalRepoPackages(context.Background(), url, tempDir, cacheLife, proxyServer)
+	d, err := NewDownloader(proxyServer)
+	if err != nil {
+		t.Fatalf("NewDownloader(%s): %v", proxyServer, err)
+	}
+	got, err := d.unmarshalRepoPackages(context.Background(), url, tempDir, cacheLife)
 	if err != nil {
 		t.Fatalf("Error running unmarshalRepoPackages: %v", err)
 	}

--- a/googet_available.go
+++ b/googet_available.go
@@ -73,8 +73,13 @@ func (cmd *availableCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...inte
 		logger.Fatal("No repos defined, create a .repo file or pass using the -sources flag.")
 	}
 
+	downloader, err := client.NewDownloader(proxyServer)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
 	m := make(map[string][]string)
-	rm := client.AvailableVersions(ctx, repos, filepath.Join(rootDir, cacheDir), cacheLife, proxyServer)
+	rm := downloader.AvailableVersions(ctx, repos, filepath.Join(rootDir, cacheDir), cacheLife)
 	for r, repo := range rm {
 		for _, p := range repo.Packages {
 			m[r] = append(m[r], p.PackageSpec.Name+"."+p.PackageSpec.Arch+"."+p.PackageSpec.Version)

--- a/googet_latest.go
+++ b/googet_latest.go
@@ -55,7 +55,12 @@ func (cmd *latestCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...int
 		logger.Fatal("No repos defined, create a .repo file or pass using the -sources flag.")
 	}
 
-	rm := client.AvailableVersions(ctx, repos, filepath.Join(rootDir, cacheDir), cacheLife, proxyServer)
+	downloader, err := client.NewDownloader(proxyServer)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	rm := downloader.AvailableVersions(ctx, repos, filepath.Join(rootDir, cacheDir), cacheLife)
 	v, _, a, err := client.FindRepoLatest(pi, rm, archs)
 	if err != nil {
 		logger.Fatal(err)

--- a/googet_remove.go
+++ b/googet_remove.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/google/googet/v2/client"
 	"github.com/google/googet/v2/goolib"
 	"github.com/google/googet/v2/remove"
 	"github.com/google/logger"
@@ -50,6 +51,11 @@ func (cmd *removeCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...int
 	state, err := readState(sf)
 	if err != nil {
 		logger.Error(err)
+	}
+
+	downloader, err := client.NewDownloader(proxyServer)
+	if err != nil {
+		logger.Fatal(err)
 	}
 
 	for _, arg := range flags.Args() {
@@ -83,7 +89,7 @@ func (cmd *removeCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...int
 			}
 		}
 		fmt.Printf("Removing %s and all dependencies...\n", pi.Name)
-		if err = remove.All(ctx, pi, deps, state, cmd.dbOnly, proxyServer); err != nil {
+		if err = remove.All(ctx, pi, deps, state, cmd.dbOnly, downloader); err != nil {
 			logger.Errorf("error removing %s, %v", arg, err)
 			exitCode = subcommands.ExitFailure
 			continue

--- a/remove/remove_test.go
+++ b/remove/remove_test.go
@@ -107,8 +107,11 @@ func TestUninstallPkg(t *testing.T) {
 			LocalPath: f.Name(),
 		},
 	}
-
-	if err := uninstallPkg(context.Background(), goolib.PackageInfo{Name: "foo"}, st, false, ""); err != nil {
+	d, err := client.NewDownloader("")
+	if err != nil {
+		t.Fatalf("NewDownloader: %v", err)
+	}
+	if err := uninstallPkg(context.Background(), goolib.PackageInfo{Name: "foo"}, st, false, d); err != nil {
 		t.Fatalf("Error running uninstallPkg: %v", err)
 	}
 


### PR DESCRIPTION
Before: Almost every HTTP GET request went through client.Get, which created a new http.Transport (inside of http.DefaultClient) for each request. The code in verify.Command created its own http.Client separately from client.Get.

After: googet creates a single http.Client via NewDownloader, which is reused for all requests, per https://pkg.go.dev/net/http#hdr-Clients_and_Transports. The downloader is passed through to anything that needs it (in place of the proxyServer URL that was formerly being passed around). verify.Command uses this same downloader.
