### PR TITLE
Fix versioning for shorter version strings

### DIFF
--- a/googet.goospec
+++ b/googet.goospec
@@ -1,4 +1,4 @@
-{{$version := "3.2.0@0" -}}
+{{$version := "3.2.1@0" -}}
 {
   "name": "googet",
   "version": "{{$version}}",
@@ -15,6 +15,7 @@
     "path": "install.ps1"
   },
   "releaseNotes": [
+    "3.2.1 - Remove offsets for semver to better support upgrading versions from X.X.X to Y.Y"
     "3.2.0  - Add Provides functionality and field to the GooGet PkgSpec.",
     "3.1.0  - Introduce a dry_run flag for update, install, and remove subcommands.",
     "3.0.0  - Replace googet state file with sqlite database. Add json output for installed command.",

--- a/goolib/goospec.go
+++ b/goolib/goospec.go
@@ -165,13 +165,12 @@ func fixVer(ver string) string {
 	}
 	out := []string{"0", "0", "0"}
 	nums := strings.SplitN(ver, ".", 3)
-	offset := len(out) - len(nums)
 	for i, str := range nums {
 		trimmed := strings.TrimLeft(str, "0")
 		if trimmed == "" {
 			trimmed = "0"
 		}
-		out[i+offset] = trimmed
+		out[i] = trimmed
 	}
 	return strings.Join(out, ".") + suffix
 }
@@ -195,8 +194,7 @@ func ComparePriorityVersion(p1 priority.Value, v1 string, p2 priority.Value, v2 
 func ParseVersion(ver string) (Version, error) {
 	v := strings.SplitN(ver, "@", 2)
 	v[0] = fixVer(v[0])
-
-	sv, err := semver.Parse(v[0])
+	sv, err := semver.ParseTolerant(v[0])
 	if err != nil {
 		return Version{}, err
 	}


### PR DESCRIPTION
Offsets currently cause a version of X.X to be compared as 0.X.X. This prevents upgrades from packages that are versioned as X.X.X as the older version will always be greater. Unless I'm missing some historical context, we should not need to offset right.