### PR TITLE
Request googet lock before creating DB

### DIFF
--- a/googet.go
+++ b/googet.go
@@ -528,6 +528,9 @@ func main() {
 	dbPath := filepath.Join(rootDir, dbFile)
 	// TODO: Move this conversion code when unused state code is cleaned up.
 	if _, err := os.Stat(dbPath); errors.Is(err, os.ErrNotExist) {
+		if err := obtainLock(lockFile); err != nil {
+			logger.Fatalf("Cannot obtain GooGet lock, you may need to run with admin rights, error: %v", err)
+		}
 		fmt.Println("Creating Googet DB and converting State file...")
 		db, err := googetdb.NewDB(dbPath)
 		if err != nil {
@@ -536,9 +539,6 @@ func main() {
 		defer db.Close()
 		// Check to see if state file still exists, then convert and remove old state. Request lock.
 		sf := filepath.Join(rootDir, stateFile)
-		if err := obtainLock(lockFile); err != nil {
-			logger.Fatalf("Cannot obtain GooGet lock, you may need to run with admin rights, error: %v", err)
-		}
 		state, err := readState(sf)
 		if err != nil {
 			logger.Fatal(err)

--- a/googet_installed.go
+++ b/googet_installed.go
@@ -68,6 +68,22 @@ func (cmd *installedCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interf
 		if err != nil {
 			logger.Fatalf("Unable to fetch installed packges: %v", err)
 		}
+		if len(state) == 0 {
+			logger.Infof("Database")
+			sf := filepath.Join(rootDir, stateFile)
+			stateFile, err := readState(sf)
+			if err != nil {
+				logger.Fatal(err)
+			}
+			if len(stateFile) > 0 {
+				logger.Info("Found empty state and existing state file, converting...")
+				db.WriteStateToDB(stateFile)
+				state, err = db.FetchPkgs()
+				if err != nil {
+					logger.Fatalf("Unable to fetch installed packges: %v", err)
+				}
+			}
+		}
 		displayText = "Installed packages:"
 	case 1:
 		pkg, err := db.FetchPkg(f.Arg(0))


### PR DESCRIPTION
- Move lock request to before we create the DB to make sure that we aren't exiting with an empty database if lock can't be obtained.
- Add failsafe in googet installed where if db is empty and a state file exists we can try the re-conversion again