### PR TITLE
Execute powershell scripts with -File instead of -Command

### DIFF
--- a/goolib/goolib.go
+++ b/goolib/goolib.go
@@ -60,8 +60,7 @@ func Exec(s string, args []string, ec []int, w io.Writer) error {
 		}
 		switch ipr {
 		case "powershell":
-			// We are using `-Command` here instead of `-File` as this catches syntax errors in the script.
-			args = append([]string{"-ExecutionPolicy", "Bypass", "-NonInteractive", "-NoProfile", "-Command", cs}, args...)
+			args = append([]string{"-ExecutionPolicy", "Bypass", "-NonInteractive", "-NoProfile", "-File", cs}, args...)
 			c = exec.Command(ipr, args...)
 		case "cmd":
 			c = exec.Command(cs, args...)


### PR DESCRIPTION
This allows exit codes from the script to be correctly captured.

When executing scripts with -Command, any non-zero exit from the script is reported as 1. When using -File, the exit code is passed through unchanged.

Prior to PowerShell v5, -File and -Command behaved differently with respect to how syntax errors were reported. This is no longer the case.