### PR TITLE
Clean the package download URLs before storing them in PackageState.

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -137,8 +137,8 @@ func packageGCS(ctx context.Context, bucket, object string, dst, chksum string) 
 	return download(r, dst, chksum)
 }
 
-// FromRepo downloads a package from a repo. It returns the path to the destination
-// file and the download URL from which the package came.
+// FromRepo downloads a package from a repo. It returns the path to the
+// downloaded file and the download URL of the package.
 func FromRepo(ctx context.Context, rs goolib.RepoSpec, repo, dir string, downloader *client.Downloader) (string, string, error) {
 	pkgURL, err := url.JoinPath(repo, "..", rs.Source)
 	if err != nil {

--- a/download/download.go
+++ b/download/download.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -138,39 +137,27 @@ func packageGCS(ctx context.Context, bucket, object string, dst, chksum string) 
 	return download(r, dst, chksum)
 }
 
-// FromRepo downloads a package from a repo.
-func FromRepo(ctx context.Context, rs goolib.RepoSpec, repo, dir string, downloader *client.Downloader) (string, error) {
-	repoURL, err := url.Parse(repo)
+// FromRepo downloads a package from a repo. It returns the path to the destination
+// file and the download URL from which the package came.
+func FromRepo(ctx context.Context, rs goolib.RepoSpec, repo, dir string, downloader *client.Downloader) (string, string, error) {
+	pkgURL, err := url.JoinPath(repo, "..", rs.Source)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	// We strip training slashes to make sure path.Dir() removes the final component (the repo name).
-	// Otherwise '/myrepo' would correctly resolve to '/', but '/myrepo/' would incorrectly resolve to '/myrepo'
-	pkgURL := &url.URL{
-		Scheme:  repoURL.Scheme,
-		Host:    repoURL.Host,
-		User:    repoURL.User,
-		RawPath: path.Join(path.Dir(strings.TrimSuffix(repoURL.EscapedPath(), "/")), rs.Source),
-	}
-	pkgURL.Path, err = url.PathUnescape(pkgURL.RawPath)
-	if err != nil {
-		return "", err
-	}
-
 	pn := goolib.PackageInfo{Name: rs.PackageSpec.Name, Arch: rs.PackageSpec.Arch, Ver: rs.PackageSpec.Version}.PkgName()
 	dst := filepath.Join(dir, filepath.Base(pn))
-	return dst, Package(ctx, pkgURL.String(), dst, rs.Checksum, downloader)
+	return dst, pkgURL, Package(ctx, pkgURL, dst, rs.Checksum, downloader)
 }
 
 // Latest downloads the latest available version of a package.
-func Latest(ctx context.Context, name, dir string, rm client.RepoMap, archs []string, downloader *client.Downloader) (string, error) {
+func Latest(ctx context.Context, name, dir string, rm client.RepoMap, archs []string, downloader *client.Downloader) (string, string, error) {
 	ver, repo, arch, err := client.FindRepoLatest(goolib.PackageInfo{Name: name, Arch: "", Ver: ""}, rm, archs)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	rs, err := client.FindRepoSpec(goolib.PackageInfo{Name: name, Arch: arch, Ver: ver}, rm[repo])
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	return FromRepo(ctx, rs, repo, dir, downloader)
 }

--- a/googet_download.go
+++ b/googet_download.go
@@ -77,7 +77,7 @@ func (cmd *downloadCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...i
 	for _, arg := range flags.Args() {
 		pi := goolib.PkgNameSplit(arg)
 		if pi.Ver == "" {
-			if _, err := download.Latest(ctx, pi.Name, dir, rm, archs, downloader); err != nil {
+			if _, _, err := download.Latest(ctx, pi.Name, dir, rm, archs, downloader); err != nil {
 				logger.Errorf("error downloading %s, %v", pi.Name, err)
 				exitCode = subcommands.ExitFailure
 			}
@@ -102,7 +102,7 @@ func (cmd *downloadCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...i
 			exitCode = subcommands.ExitFailure
 			continue
 		}
-		if _, err := download.FromRepo(ctx, rs, repo, dir, downloader); err != nil {
+		if _, _, err := download.FromRepo(ctx, rs, repo, dir, downloader); err != nil {
 			logger.Errorf("error downloading %s.%s %s, %v", pi.Name, pi.Arch, pi.Ver, err)
 			exitCode = subcommands.ExitFailure
 			continue

--- a/install/install.go
+++ b/install/install.go
@@ -161,7 +161,7 @@ func FromRepo(ctx context.Context, pi goolib.PackageInfo, repo, cache string, rm
 
 	state.Add(client.PackageState{
 		SourceRepo:     repo,
-		DownloadURL:    pkgURL, 
+		DownloadURL:    pkgURL,
 		Checksum:       rs.Checksum,
 		LocalPath:      dst,
 		PackageSpec:    rs.PackageSpec,

--- a/install/install.go
+++ b/install/install.go
@@ -143,7 +143,7 @@ func FromRepo(ctx context.Context, pi goolib.PackageInfo, repo, cache string, rm
 		return err
 	}
 
-	dst, err := download.FromRepo(ctx, rs, repo, cache, downloader)
+	dst, pkgURL, err := download.FromRepo(ctx, rs, repo, cache, downloader)
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func FromRepo(ctx context.Context, pi goolib.PackageInfo, repo, cache string, rm
 
 	state.Add(client.PackageState{
 		SourceRepo:     repo,
-		DownloadURL:    strings.TrimSuffix(repo, filepath.Base(repo)) + rs.Source,
+		DownloadURL:    pkgURL, 
 		Checksum:       rs.Checksum,
 		LocalPath:      dst,
 		PackageSpec:    rs.PackageSpec,


### PR DESCRIPTION
Instead of "https://my-googet-server/repos/../packages/my.goo", store "http://my-googet-server/packages/my.goo".

This returns the resolved package URL from download.FromRepo and download.Latest.

Also simplify the code for resolving the package URL by using url.JoinPath.