### PR TITLE
Update googetdb fetch query to support "." for exact package matches.

### DIFF
--- a/googetdb/googetdb.go
+++ b/googetdb/googetdb.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/googet/v2/client"
@@ -179,6 +180,9 @@ func (g *gooDB) FetchPkgs(pkgName string) (client.GooGetState, error) {
 	pkgQuery := `Select pkg_name from InstalledPackages`
 	if pkgName != "" {
 		pkgQuery = fmt.Sprintf(`Select pkg_name from InstalledPackages where pkg_name like "%s%%"`, pkgName)
+		if strings.HasSuffix(pkgName, ".") {
+			pkgQuery = fmt.Sprintf(`Select pkg_name from InstalledPackages where pkg_name = "%s"`, pkgName[:len(pkgName)-1])
+		}
 	}
 	pkgs, err := g.db.Query(pkgQuery)
 	if err != nil {


### PR DESCRIPTION
In previous version of googet, you could type "googet installed packagename." to get exact matches of pacakges by adding a "." to the end of your query. Since the db changes, this has been inadvertently removed. Adding the feature back in. 