### PR TITLE
Fix detection logic for smaller package names

### DIFF
--- a/googet_check.go
+++ b/googet_check.go
@@ -84,7 +84,7 @@ func (cmd *checkCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfac
 			if _, ok := installed[p.PackageSpec.Name]; ok {
 				continue
 			}
-			app, _ := system.AppAssociation(p.PackageSpec.Authors, "", p.PackageSpec.Name, filepath.Ext(p.PackageSpec.Install.Path))
+			app, _ := system.AppAssociation(p.PackageSpec, "")
 			if app != "" {
 				unmanaged[p.PackageSpec.Name] = app
 				if cmd.dryRun {

--- a/googetdb/googetdb.go
+++ b/googetdb/googetdb.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/google/googet/v2/client"
@@ -105,8 +104,10 @@ func (g *gooDB) WriteStateToDB(gooState client.GooGetState) error {
 
 func (g *gooDB) addPkg(pkgState client.PackageState) error {
 	spec := pkgState.PackageSpec
-	pkgState.InstalledApp.Name, pkgState.InstalledApp.Reg = system.AppAssociation(spec.Authors, pkgState.LocalPath, spec.Name, filepath.Ext(spec.Install.Path))
+
+	pkgState.InstalledApp.Name, pkgState.InstalledApp.Reg = system.AppAssociation(spec, pkgState.LocalPath)
 	pkgState.InstallDate = time.Now().Unix()
+
 	tx, err := g.db.Begin()
 	if err != nil {
 		return err

--- a/system/system_linux.go
+++ b/system/system_linux.go
@@ -77,6 +77,6 @@ func InstallableArchs() ([]string, error) {
 }
 
 // AppAssociation returns empty strings and is a stub of the Windows implementation.
-func AppAssociation(publisher, installSource, programName, extension string) (string, string) {
+func AppAssociation(ps *goolib.PkgSpec, installSource string) (string, string) {
 	return "", ""
 }

--- a/system/system_windows.go
+++ b/system/system_windows.go
@@ -117,8 +117,11 @@ func removeUninstallEntry(name string) error {
 }
 
 // AppAssociation locates and returns registry entry and name of installed application.
-func AppAssociation(publisher, installSource, programName, extension string) (string, string) {
-
+func AppAssociation(ps *goolib.PkgSpec, installSource string) (string, string) {
+	// Packages with files are portable and don't have actual installers. 
+	if ps.Files != nil {
+		return "", ""
+	}
 	var productroots = []string{
 		`SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\`,
 		`SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\`,
@@ -145,7 +148,7 @@ func AppAssociation(publisher, installSource, programName, extension string) (st
 				continue
 			}
 
-			if extension == ".msi" && installSource != "" {
+			if filepath.Ext(ps.Install.Path) == ".msi" && installSource != "" {
 				a, _, err := q.GetStringValue("InstallSource")
 				if err != nil {
 					// InstallSource not found, move on to next entry
@@ -162,29 +165,37 @@ func AppAssociation(publisher, installSource, programName, extension string) (st
 				}
 			}
 			// TODO: Look into precompiling regex
+			var publisher, programName string
 			for _, v := range publisherNameReg {
 				re := regexp.MustCompile("(?i)" + regex[v])
-				publisher = re.ReplaceAllString(publisher, "")
+				publisher = re.ReplaceAllString(ps.Authors, "")
 			}
 			for _, v := range programNameReg {
 				re := regexp.MustCompile("(?i)" + regex[v])
-				programName = re.ReplaceAllString(programName, "")
+				programName = re.ReplaceAllString(ps.Name, "")
 			}
 			// Ignore empty and googet labeled pacakges
 			if displayName == "" || strings.Contains(displayName, "GooGet -") {
 				continue
 			}
 			// Check if Package name is in display name removing spaces
+			regPublisher, _, err := q.GetStringValue("Publisher")
+			if err != nil {
+				continue
+			}
 			if strings.Contains(strings.ToLower(strings.ReplaceAll(displayName, " ", "")), strings.ToLower(programName)) {
 				// Do an extra check for publisher for smaller package names and gain more confidence that we are returning the right package.
-				if len(programName) < 4 && !strings.Contains(strings.ToLower(strings.ReplaceAll(publisher, " ", "")), strings.ToLower(publisher)) {
+				if len(programName) < 4 && !strings.Contains(strings.ToLower(strings.ReplaceAll(regPublisher, " ", "")), strings.ToLower(publisher)) {
 					return "", ""
 				}
 				return displayName, productReg
 			}
 			// Check if Package name is in display name removing dashes
 			if strings.Contains(strings.ToLower(strings.ReplaceAll(displayName, "-", "")), strings.ToLower(programName)) {
-				// Check if the value exists, move on if it doesn't
+				// Do an extra check for publisher for smaller package names and gain more confidence that we are returning the right package.
+				if len(programName) < 4 && !strings.Contains(strings.ToLower(strings.ReplaceAll(regPublisher, " ", "")), strings.ToLower(publisher)) {
+					return "", ""
+				}
 				return displayName, productReg
 			}
 			a, _, err := q.GetStringValue("InstallSource")

--- a/system/system_windows.go
+++ b/system/system_windows.go
@@ -118,7 +118,7 @@ func removeUninstallEntry(name string) error {
 
 // AppAssociation locates and returns registry entry and name of installed application.
 func AppAssociation(ps *goolib.PkgSpec, installSource string) (string, string) {
-	// Packages with files are portable and don't have actual installers. 
+	// Packages with files are portable and don't have actual installers.
 	if ps.Files != nil {
 		return "", ""
 	}
@@ -185,6 +185,7 @@ func AppAssociation(ps *goolib.PkgSpec, installSource string) (string, string) {
 			}
 			if strings.Contains(strings.ToLower(strings.ReplaceAll(displayName, " ", "")), strings.ToLower(programName)) {
 				// Do an extra check for publisher for smaller package names and gain more confidence that we are returning the right package.
+				fmt.Printf("%v: %v", regPublisher, publisher)
 				if len(programName) < 4 && !strings.Contains(strings.ToLower(strings.ReplaceAll(regPublisher, " ", "")), strings.ToLower(publisher)) {
 					return "", ""
 				}


### PR DESCRIPTION
- Make appassociation accept pkgspec so we can do all association logic there(instead of in check and db code)
- Check for publisher matches on smaller applications
- Omit any package with "Files". This typically denotes portable apps that do not have installers.