### PR TITLE
Don't panic when checking short filenames for path traversal.

### DIFF
--- a/download/download.go
+++ b/download/download.go
@@ -226,7 +226,7 @@ func ExtractPkg(src string) (dst string, err error) {
 		}
 
 		name := filepath.Clean(header.Name)
-		if name[0:3] == ".."+string(os.PathSeparator) {
+		if strings.HasPrefix(name, ".."+string(os.PathSeparator)) {
 			return "", fmt.Errorf("error unpacking package, file contains path traversal: %q", name)
 		}
 


### PR DESCRIPTION
If the tarfile contains a filename with len < 3, this panics.

Fixes #155.