### PR TITLE
Refactor googet_install and add integration tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,12 +16,13 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 'stable'
+        check-latest: true
 
     - name: Format
       run: |
@@ -44,12 +45,13 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.23.x
+        go-version: 'stable'
+        check-latest: true
 
     - name: Vet
       run: go vet ./...

--- a/googet_install.go
+++ b/googet_install.go
@@ -18,6 +18,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -51,162 +52,185 @@ func (cmd *installCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&cmd.sources, "sources", "", "comma separated list of sources, setting this overrides local .repo files")
 }
 
-func (cmd *installCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	db, err := googetdb.NewDB(filepath.Join(rootDir, dbFile))
-	if err != nil {
-		logger.Fatal(err)
-	}
-	defer db.Close()
-	var state client.GooGetState
-	if len(flags.Args()) == 0 {
+func (cmd *installCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...any) subcommands.ExitStatus {
+	if flags.NArg() == 0 {
 		fmt.Printf("%s\nUsage: %s\n", cmd.Synopsis(), cmd.Usage())
 		return subcommands.ExitFailure
 	}
-
 	if cmd.redownload && !cmd.reinstall {
 		fmt.Fprintln(os.Stderr, "It's an error to use the -redownload flag without the -reinstall flag")
 		return subcommands.ExitFailure
 	}
 
-	args := flags.Args()
-	exitCode := subcommands.ExitSuccess
-
-	cache := filepath.Join(rootDir, cacheDir)
-
-	if len(args) == 0 {
-		return exitCode
-	}
-
-	repos, err := buildSources(cmd.sources)
+	db, err := googetdb.NewDB(filepath.Join(rootDir, dbFile))
 	if err != nil {
 		logger.Fatal(err)
 	}
+	defer db.Close()
 
 	downloader, err := client.NewDownloader(proxyServer)
 	if err != nil {
 		logger.Fatal(err)
 	}
 
-	var rm client.RepoMap
-	for _, arg := range args {
-		if ext := filepath.Ext(arg); ext == ".goo" {
-			if !noConfirm {
-				if base := filepath.Base(arg); !confirmation(fmt.Sprintf("Install %s?", base)) {
-					fmt.Printf("Not installing %s...\n", base)
-					continue
-				}
-			}
-			// Pull the whole state to check against local pkgspec.
-			state, err = db.FetchPkgs("")
-			if err != nil {
-				logger.Fatalf("Unable to fetch installed packges: %v", err)
-			}
-			insPkg, err := install.FromDisk(arg, cache, &state, cmd.dbOnly, cmd.reinstall)
-			if err != nil {
-				logger.Errorf("Error installing %s: %v", arg, err)
-				exitCode = subcommands.ExitFailure
-				continue
-			}
-			if err := db.WriteStateToDB(insPkg); err != nil {
-				logger.Fatalf("Error writing state database: %v", err)
+	i := &installer{
+		db:              db,
+		cache:           filepath.Join(rootDir, cacheDir),
+		dbOnly:          cmd.dbOnly,
+		shouldReinstall: cmd.reinstall,
+		redownload:      cmd.redownload,
+		confirm:         !noConfirm,
+		downloader:      downloader,
+	}
+
+	// We only need to build sources and download indexes if there are any
+	// non-file goo arguments passed to the install command (usually the case).
+	if !allFileGoos(flag.Args()) {
+		repos, err := buildSources(cmd.sources)
+		if err != nil {
+			logger.Fatal(err)
+		}
+		if repos == nil {
+			logger.Fatal("No repos defined, create a .repo file or pass using the -sources flag.")
+		}
+		i.repoMap = i.downloader.AvailableVersions(ctx, repos, i.cache, cacheLife)
+	}
+
+	var errs error
+	for _, arg := range flags.Args() {
+		if filepath.Ext(arg) == ".goo" {
+			if err := i.installFromFile(arg); err != nil {
+				logger.Errorf("Error installing %q from file: %v", arg, err)
+				errs = errors.Join(errs, err)
 			}
 			continue
 		}
 
-		pi := goolib.PkgNameSplit(arg)
-		pkgState, err := db.FetchPkg(pi.Name)
-		if err != nil {
-			logger.Fatalf("Unable to fetch %v: %v", pi.Name, err)
-		}
-		if cmd.reinstall {
-			if pkgState.PackageSpec == nil {
-				fmt.Printf("package %s not installed on the system.\n", pi.Name)
-				continue
-			}
-			if err := reinstall(ctx, pi, pkgState, cmd.redownload, downloader); err != nil {
-				logger.Errorf("Error reinstalling %s: %v", pi.Name, err)
-				exitCode = subcommands.ExitFailure
-				continue
-			}
-			if err := db.WriteStateToDB(client.GooGetState{pkgState}); err != nil {
-				logger.Fatalf("Error writing state db: %v", err)
-			}
-			continue
-		}
-		if len(rm) == 0 {
-			if repos == nil {
-				logger.Fatal("No repos defined, create a .repo file or pass using the -sources flag.")
-			}
-			rm = downloader.AvailableVersions(ctx, repos, filepath.Join(rootDir, cacheDir), cacheLife)
-		}
-		if pi.Ver == "" {
-			v, _, a, err := client.FindRepoLatest(pi, rm, archs)
-			pi.Ver, pi.Arch = v, a
-			if err != nil {
-				logger.Errorf("Can't resolve version for package %q: %v", pi.Name, err)
-				exitCode = subcommands.ExitFailure
-				continue
-			}
-		}
-		if _, err := goolib.ParseVersion(pi.Ver); err != nil {
-			logger.Errorf("Invalid package version %q: %v", pi.Ver, err)
-			exitCode = subcommands.ExitFailure
-			continue
-		}
-
-		r, err := client.WhatRepo(pi, rm)
-		if err != nil {
-			logger.Errorf("Error finding %s.%s.%s in repo: %v", pi.Name, pi.Arch, pi.Ver, err)
-			exitCode = subcommands.ExitFailure
-			continue
-		}
-		state = client.GooGetState{pkgState}
-		ni, err := install.NeedsInstallation(pi, state)
-		if err != nil {
-			logger.Error(err)
-			exitCode = subcommands.ExitFailure
-			continue
-		}
-		if !ni {
-			fmt.Printf("%s.%s.%s or a newer version is already installed on the system\n", pi.Name, pi.Arch, pi.Ver)
-			continue
-		}
-		if !noConfirm {
-			b, err := enumerateDeps(pi, rm, r, archs, state)
-			if err != nil {
-				logger.Error(err)
-				exitCode = subcommands.ExitFailure
-				continue
-			}
-			if !confirmation(b.String()) {
-				fmt.Println("canceling install...")
-				continue
-			}
-		}
-		if err := install.FromRepo(ctx, pi, r, cache, rm, archs, &state, cmd.dbOnly, downloader); err != nil {
-			logger.Errorf("Error installing %s.%s.%s: %v", pi.Name, pi.Arch, pi.Ver, err)
-			exitCode = subcommands.ExitFailure
-			continue
-		}
-		if err := db.WriteStateToDB(state); err != nil {
-			logger.Fatalf("error writing state file: %v", err)
+		// TODO: archs should not be a global variable.
+		if err := i.installFromRepo(ctx, arg, archs); err != nil {
+			logger.Errorf("Error installing from %q from repo: %v", arg, err)
+			errs = errors.Join(errs, err)
 		}
 	}
-	return exitCode
+
+	if errs != nil {
+		return subcommands.ExitFailure
+	}
+	return subcommands.ExitSuccess
 }
 
-func reinstall(ctx context.Context, pi goolib.PackageInfo, ps client.PackageState, rd bool, downloader *client.Downloader) error {
+// allFileGoos returns true if every element of ls represents a path to a .goo
+func allFileGoos(ls []string) bool {
+	for _, s := range ls {
+		if filepath.Ext(s) != ".goo" {
+			return false
+		}
+	}
+	return true
+}
+
+// installer handles install actions
+type installer struct {
+	db              *googetdb.GooDB    // the googet database storing package state
+	cache           string             // path to cache directory
+	downloader      *client.Downloader // HTTP client
+	repoMap         client.RepoMap     // packages available for install
+	dbOnly          bool               // update database without actually installing
+	shouldReinstall bool               // install even if already installed
+	redownload      bool               // ignore cached downloads when reinstalling
+	confirm         bool               // prompt before changes
+}
+
+// installFromFile installs a package from the specified file path.
+func (i *installer) installFromFile(path string) error {
+	base := filepath.Base(path)
+	if i.confirm && !confirmation(fmt.Sprintf("Install %s?", base)) {
+		fmt.Printf("Not installing %s...\n", base)
+		return nil
+	}
+	// Pull the whole state to check against local pkgspec.
+	state, err := i.db.FetchPkgs("")
+	if err != nil {
+		return fmt.Errorf("unable to fetch installed packages: %v", err)
+	}
+	insPkg, err := install.FromDisk(path, i.cache, &state, i.dbOnly, i.shouldReinstall)
+	if err != nil {
+		return fmt.Errorf("installing %s: %v", path, err)
+	}
+	if err := i.db.WriteStateToDB(insPkg); err != nil {
+		return fmt.Errorf("writing state database: %v", err)
+	}
+	return nil
+}
+
+// installFromRepo installs the named package from a repo.
+func (i *installer) installFromRepo(ctx context.Context, name string, archs []string) error {
+	pi := goolib.PkgNameSplit(name)
+	pkgState, err := i.db.FetchPkg(pi.Name)
+	if err != nil {
+		return fmt.Errorf("unable to fetch %v: %v", pi.Name, err)
+	}
+	if i.shouldReinstall {
+		if err := i.reinstall(ctx, pi, pkgState); err != nil {
+			return fmt.Errorf("reinstalling %s: %v", pi.Name, err)
+		}
+		if err := i.db.WriteStateToDB(client.GooGetState{pkgState}); err != nil {
+			return fmt.Errorf("writing state db: %v", err)
+		}
+		return nil
+	}
+
+	if pi.Ver == "" {
+		if pi.Ver, _, pi.Arch, err = client.FindRepoLatest(pi, i.repoMap, archs); err != nil {
+			return fmt.Errorf("can't resolve version for package %q: %v", pi.Name, err)
+		}
+	}
+	if _, err := goolib.ParseVersion(pi.Ver); err != nil {
+		return fmt.Errorf("invalid package version %q: %v", pi.Ver, err)
+	}
+
+	r, err := client.WhatRepo(pi, i.repoMap)
+	if err != nil {
+		return fmt.Errorf("error finding %s.%s.%s in repo: %v", pi.Name, pi.Arch, pi.Ver, err)
+	}
+	state := client.GooGetState{pkgState}
+	if ni, err := install.NeedsInstallation(pi, state); err != nil {
+		return err
+	} else if !ni {
+		fmt.Printf("%s.%s.%s or a newer version is already installed on the system\n", pi.Name, pi.Arch, pi.Ver)
+		return nil
+	}
+	if i.confirm {
+		b, err := enumerateDeps(pi, i.repoMap, r, archs, state)
+		if err != nil {
+			return err
+		}
+		if !confirmation(b.String()) {
+			fmt.Println("canceling install...")
+			return nil
+		}
+	}
+	if err := install.FromRepo(ctx, pi, r, i.cache, i.repoMap, archs, &state, i.dbOnly, i.downloader); err != nil {
+		return fmt.Errorf("installing %s.%s.%s: %v", pi.Name, pi.Arch, pi.Ver, err)
+	}
+	if err := i.db.WriteStateToDB(state); err != nil {
+		return fmt.Errorf("writing state file: %v", err)
+	}
+	return nil
+}
+
+func (i *installer) reinstall(ctx context.Context, pi goolib.PackageInfo, ps client.PackageState) error {
 	// TODO: Cleanup reinstall logic to remove pi
 	if pi.Name == "" {
 		return fmt.Errorf("cannot reinstall something that is not already installed")
 	}
-	if !noConfirm {
+	if i.confirm {
 		if !confirmation(fmt.Sprintf("Reinstall %s?", pi.Name)) {
 			fmt.Printf("Not reinstalling %s...\n", pi.Name)
 			return nil
 		}
 	}
-	if err := install.Reinstall(ctx, ps, rd, downloader); err != nil {
+	if err := install.Reinstall(ctx, ps, i.redownload, i.downloader); err != nil {
 		return fmt.Errorf("error reinstalling %s, %v", pi.Name, err)
 	}
 	return nil

--- a/googet_install_test.go
+++ b/googet_install_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/googet/v2/client"
+	"github.com/google/googet/v2/googetdb"
+	"github.com/google/googet/v2/goolib"
+	"github.com/google/googet/v2/priority"
+)
+
+// genGoo creates a name.noarch.version.goo package file in directory dir
+// for the package with given name and version. When installed
+// name.goo writes a file having same name as the package to the
+// dst directory. The contents of this file is "name.noarch.version".
+// Returns a RepoSpec for the goo package.
+func genGoo(t *testing.T, dir, dst string, pi goolib.PackageInfo) goolib.RepoSpec {
+	t.Helper()
+	ps := goolib.PkgSpec{
+		Name:    pi.Name,
+		Arch:    pi.Arch,
+		Version: pi.Ver,
+		Files:   map[string]string{pi.Name: filepath.Join(dst, pi.Name)},
+	}
+	b, err := json.Marshal(ps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(filepath.Join(dir, ps.String()+".goo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	gw := gzip.NewWriter(io.MultiWriter(h, f))
+	tw := tar.NewWriter(gw)
+	modTime := time.Now()
+	for _, x := range []struct {
+		name    string
+		content []byte
+	}{
+		{pi.Name, []byte(ps.String())},
+		{pi.Name + ".pkgspec", b},
+	} {
+		if err := tw.WriteHeader(&tar.Header{Name: x.name, Mode: 0644, Size: int64(len(x.content)), ModTime: modTime}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(x.content); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tw.Close()
+	gw.Close()
+	return goolib.RepoSpec{
+		Checksum:    fmt.Sprintf("%x", h.Sum(nil)),
+		Source:      filepath.Base(f.Name()),
+		PackageSpec: &ps,
+	}
+}
+
+// serveGoo returns an HTTP server that serves files from dir.
+func serveGoo(t *testing.T, dir string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f, err := os.Open(filepath.Join(dir, r.URL.Path))
+		if err != nil {
+			t.Logf("couldn't find file: %v", r.URL.Path)
+			http.Error(w, "couldn't find requested file", http.StatusNotFound)
+		} else {
+			io.Copy(w, f)
+			f.Close()
+		}
+	}))
+}
+
+// checkInstalled returns true if the test package identified by ps was
+// installed, based on whether or not the package file was written.
+func checkInstalled(t *testing.T, dir string, ps goolib.PackageInfo) bool {
+	t.Helper()
+	filename := filepath.Join(dir, ps.Name)
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+		t.Fatalf("checkInstalled: error reading %q: %v", filename, err)
+	}
+	if got, want := string(b), ps.String(); got != want {
+		t.Fatalf("checkInstalled: %q content got %v, want %v", filename, got, want)
+	}
+	return true
+}
+
+func TestInstall(t *testing.T) {
+	for _, tc := range []struct {
+		desc          string             // description of test case
+		args          []string           // args to install command
+		state         client.GooGetState // initial DB package state
+		packages      []string           // which packages to provide in repo map
+		wantInstalled []string           // which packages were actually installed
+		wantState     []string           // representation of final DB package state
+	}{
+		{
+			desc:          "single-install",
+			args:          []string{"A"},
+			state:         client.GooGetState{},
+			packages:      []string{"A.noarch.1"},
+			wantInstalled: []string{"A.noarch.1"},
+			wantState:     []string{"A.noarch.1"},
+		},
+		{
+			desc:          "one-already-installed",
+			args:          []string{"A", "B"},
+			state:         client.GooGetState{{PackageSpec: &goolib.PkgSpec{Name: "A", Arch: "noarch", Version: "1"}}},
+			packages:      []string{"A.noarch.1", "B.noarch.2"},
+			wantInstalled: []string{"B.noarch.2"},
+			wantState:     []string{"A.noarch.1", "B.noarch.2"},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Set up the installer.
+			dbDir := t.TempDir()
+			db, err := googetdb.NewDB(filepath.Join(dbDir, dbFile))
+			if err != nil {
+				t.Fatalf("googetdb.NewDB: %v", err)
+			}
+			if err := db.WriteStateToDB(tc.state); err != nil {
+				t.Fatalf("db.WriteStateToDB: %v", err)
+			}
+			defer db.Close()
+			downloader, err := client.NewDownloader("")
+			if err != nil {
+				t.Fatalf("NewDownloader: %v", err)
+			}
+			i := installer{
+				db:         db,
+				cache:      t.TempDir(),
+				downloader: downloader,
+			}
+			// Set up the test server.
+			gooDir, logDir := t.TempDir(), t.TempDir()
+			srv := serveGoo(t, gooDir)
+			defer srv.Close()
+			// Set up the test goo packages.
+			var specs []goolib.RepoSpec
+			for _, pkg := range tc.packages {
+				pi := goolib.PkgNameSplit(pkg)
+				rs := genGoo(t, gooDir, logDir, pi)
+				specs = append(specs, rs)
+			}
+			// Initialize the installer's repo map.
+			i.repoMap = client.RepoMap{srv.URL: client.Repo{Priority: priority.Default, Packages: specs}}
+			// Install everything.
+			archs := []string{"noarch"}
+			for _, arg := range tc.args {
+				if err := i.installFromRepo(t.Context(), arg, archs); err != nil {
+					t.Fatalf("installFromRepo: %v", err)
+				}
+			}
+			// Check that expected installs occurred.
+			for _, pkg := range tc.packages {
+				if got, want := checkInstalled(t, logDir, goolib.PkgNameSplit(pkg)), slices.Contains(tc.wantInstalled, pkg); got != want {
+					t.Fatalf("package %q installed got: %v, want: %v", pkg, got, want)
+				}
+			}
+			// Check that database looks right.
+			state, err := db.FetchPkgs("")
+			if err != nil {
+				t.Fatalf("db.FetchPkgs: %v", err)
+			}
+			var gotState []string
+			for _, ps := range state {
+				gotState = append(gotState, ps.PackageSpec.String())
+			}
+			if diff := cmp.Diff(tc.wantState, gotState, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+				t.Fatalf("unexpected db state (-want +got):\n%v", diff)
+			}
+		})
+	}
+}

--- a/googetdb/googetdb.go
+++ b/googetdb/googetdb.go
@@ -34,13 +34,14 @@ const (
 		?, ?, ?, ?)`
 )
 
-type gooDB struct {
+// GooDB is the googet database.
+type GooDB struct {
 	db *sql.DB
 }
 
 // NewDB returns the googet DB object
-func NewDB(dbFile string) (*gooDB, error) {
-	var gdb gooDB
+func NewDB(dbFile string) (*GooDB, error) {
+	var gdb GooDB
 	var err error
 	if _, err := os.Stat(dbFile); errors.Is(err, os.ErrNotExist) {
 		gdb.db, err = createDB(dbFile)
@@ -57,7 +58,7 @@ func NewDB(dbFile string) (*gooDB, error) {
 }
 
 // Close will close the db connection
-func (g *gooDB) Close() error {
+func (g *GooDB) Close() error {
 	return g.db.Close()
 }
 
@@ -89,7 +90,7 @@ func createDB(dbFile string) (*sql.DB, error) {
 }
 
 // WriteStateToDB writes new or partial state to the db.
-func (g *gooDB) WriteStateToDB(gooState client.GooGetState) error {
+func (g *GooDB) WriteStateToDB(gooState client.GooGetState) error {
 	for _, pkgState := range gooState {
 		if pkgState.PackageSpec == nil {
 			continue
@@ -102,7 +103,7 @@ func (g *gooDB) WriteStateToDB(gooState client.GooGetState) error {
 	return nil
 }
 
-func (g *gooDB) addPkg(pkgState client.PackageState) error {
+func (g *GooDB) addPkg(pkgState client.PackageState) error {
 	spec := pkgState.PackageSpec
 
 	pkgState.InstalledApp.Name, pkgState.InstalledApp.Reg = system.AppAssociation(spec, pkgState.LocalPath)
@@ -129,7 +130,7 @@ func (g *gooDB) addPkg(pkgState client.PackageState) error {
 }
 
 // RemovePkg removes a single package from the googet database
-func (g *gooDB) RemovePkg(packageName, arch string) error {
+func (g *GooDB) RemovePkg(packageName, arch string) error {
 	removeQuery := fmt.Sprintf(`BEGIN;
 	DELETE FROM InstalledPackages where pkg_name = '%v' and pkg_arch = '%v';
 	COMMIT;`, packageName, arch)
@@ -142,7 +143,7 @@ func (g *gooDB) RemovePkg(packageName, arch string) error {
 }
 
 // FetchPkg exports a single package from the googet database
-func (g *gooDB) FetchPkg(pkgName string) (client.PackageState, error) {
+func (g *GooDB) FetchPkg(pkgName string) (client.PackageState, error) {
 	var pkgState client.PackageState
 
 	selectSpecQuery :=
@@ -175,7 +176,7 @@ func (g *gooDB) FetchPkg(pkgName string) (client.PackageState, error) {
 }
 
 // FetchPkgs exports all of the current packages in the googet database
-func (g *gooDB) FetchPkgs(pkgName string) (client.GooGetState, error) {
+func (g *GooDB) FetchPkgs(pkgName string) (client.GooGetState, error) {
 	var state client.GooGetState
 	pkgQuery := `Select pkg_name from InstalledPackages`
 	if pkgName != "" {


### PR DESCRIPTION
This moves most of the googet_install code out of Execute so that it can be tested. More of a first step towards refactoring than final end state, since googet_install.go should not be part of the main package and I'm not certain any of the installer code actually belongs here.

Adds an end-to-end integration test for installing packages which tests finding, downloading, extracting, installing, and modifying the database package state. Will add more test cases in future PRs.