### PR TITLE
Move state file to db conversion code into googetdb.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -103,17 +103,6 @@ func (s GooGetState) PackageMap() PackageMap {
 	return pm
 }
 
-// Marshal JSON marshals GooGetState.
-func (s *GooGetState) Marshal() ([]byte, error) {
-	return json.Marshal(s)
-}
-
-// UnmarshalState unmarshals data into GooGetState.
-func UnmarshalState(b []byte) (*GooGetState, error) {
-	var s GooGetState
-	return &s, json.Unmarshal(b, &s)
-}
-
 // Match reports whether the PackageState corresponds to the package info.
 func (ps *PackageState) Match(pi goolib.PackageInfo) bool {
 	return ps.PackageSpec.Name == pi.Name && (ps.PackageSpec.Arch == pi.Arch || pi.Arch == "") && (ps.PackageSpec.Version == pi.Ver || pi.Ver == "")

--- a/googet.go
+++ b/googet.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/googet/v2/client"
 	"github.com/google/googet/v2/googetdb"
 	"github.com/google/googet/v2/goolib"
 	"github.com/google/googet/v2/priority"
@@ -202,57 +201,6 @@ func repos(dir string) ([]repoFile, error) {
 		}
 	}
 	return rfs, nil
-}
-
-func writeState(s *client.GooGetState, sf string) error {
-	b, err := s.Marshal()
-	if err != nil {
-		return err
-	}
-	// Write state to a temporary file first
-	tmp, err := ioutil.TempFile(settings.RootDir, "googet.*.state")
-	if err != nil {
-		return err
-	}
-	newStateFile := tmp.Name()
-	if _, err = tmp.Write(b); err != nil {
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Chmod(newStateFile, 0664); err != nil {
-		return err
-	}
-	// Back up the old state file so we can recover it if need be
-	backupStateFile := sf + ".bak"
-	if err = os.Rename(sf, backupStateFile); err != nil {
-		logger.Infof("Unable to back up state file %s to %s. Err: %v", sf, backupStateFile, err)
-	}
-	// Move the new temp file to the live path
-	return os.Rename(newStateFile, sf)
-}
-
-func readState(sf string) (client.GooGetState, error) {
-	state, err := readStateFromPath(sf)
-	if err != nil {
-		sfNotExist := os.IsNotExist(err)
-		state, err = readStateFromPath(sf + ".bak")
-		if sfNotExist && os.IsNotExist(err) {
-			logger.Info("No state file found, assuming no packages installed.")
-			return client.GooGetState{}, nil
-		}
-	}
-
-	return *state, err
-}
-
-func readStateFromPath(sf string) (*client.GooGetState, error) {
-	b, err := ioutil.ReadFile(sf)
-	if err != nil {
-		return nil, err
-	}
-	return client.UnmarshalState(b)
 }
 
 func buildSources(s string) (map[string]priority.Value, error) {
@@ -441,7 +389,7 @@ func main() {
 	cmdr.ImportantFlag("noconfirm")
 
 	nonLockingCommands := []string{"help", "commands", "flags", "listrepos"}
-	if flag.NArg() == 0 || slices.Contains(nonLockingCommands, flag.Args()[0]) {
+	if flag.NArg() == 0 || slices.Contains(nonLockingCommands, flag.Arg(0)) {
 		os.Exit(int(cmdr.Execute(context.Background())))
 	}
 
@@ -453,34 +401,16 @@ func main() {
 	}
 	settings.Initialize(*rootDir, !*noConfirm)
 
-	lockFile := settings.LockFile()
-	dbPath := settings.DBFile()
-	// TODO: Move this conversion code when unused state code is cleaned up.
-	if _, err := os.Stat(dbPath); errors.Is(err, os.ErrNotExist) {
-		if err := obtainLock(lockFile); err != nil {
-			logger.Fatalf("Cannot obtain GooGet lock, you may need to run with admin rights, error: %v", err)
-		}
-		fmt.Println("Creating Googet DB and converting State file...")
-		db, err := googetdb.NewDB(dbPath)
-		if err != nil {
-			logger.Fatalf("Unable to create initial db file. If db is not created, run again as admin: %v", err)
-		}
-		defer db.Close()
-		// Check to see if state file still exists, then convert and remove old state. Request lock.
-		state, err := readState(settings.StateFile())
-		if err != nil {
-			logger.Fatal(err)
-		}
-		db.WriteStateToDB(state)
-	} else {
-		// Allow installed to run through sql db creation
-		if flag.Args()[0] == "installed" {
-			os.Exit(int(cmdr.Execute(context.Background())))
-		}
-		// If we converted the db, we don't want to request the lock twice.
-		if err := obtainLock(lockFile); err != nil {
-			logger.Fatalf("Cannot obtain GooGet lock, you may need to run with admin rights, error: %v", err)
-		}
+	dbFile := settings.DBFile()
+
+	// "googet installed" is allowed to execute without a lock if the googet
+	// database has already been created.
+	if googetdb.Exists(dbFile) && flag.Arg(0) == "installed" {
+		os.Exit(int(cmdr.Execute(context.Background())))
+	}
+
+	if err := obtainLock(settings.LockFile()); err != nil {
+		logger.Fatalf("Cannot obtain GooGet lock, you may need to run with admin rights, error: %v", err)
 	}
 
 	logPath := settings.LogFile()
@@ -496,6 +426,10 @@ func main() {
 
 	logger.Init("GooGet", *verbose, *systemLog, lf)
 
+	if err := googetdb.CreateIfMissing(dbFile); err != nil {
+		runDeferredFuncs()
+		logger.Fatalf("Error creating initial db file. If db is not created, run again as admin: %v", err)
+	}
 	if err := os.MkdirAll(settings.CacheDir(), 0774); err != nil {
 		runDeferredFuncs()
 		logger.Fatalf("Error setting up cache directory: %v", err)

--- a/googet_installed.go
+++ b/googet_installed.go
@@ -67,22 +67,7 @@ func (cmd *installedCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interf
 	case 0:
 		state, err = db.FetchPkgs("")
 		if err != nil {
-			logger.Fatalf("Unable to fetch installed packges: %v", err)
-		}
-		if len(state) == 0 {
-			logger.Infof("Database")
-			stateFile, err := readState(settings.StateFile())
-			if err != nil {
-				logger.Fatal(err)
-			}
-			if len(stateFile) > 0 {
-				logger.Info("Found empty state and existing state file, converting...")
-				db.WriteStateToDB(stateFile)
-				state, err = db.FetchPkgs("")
-				if err != nil {
-					logger.Fatalf("Unable to fetch installed packges: %v", err)
-				}
-			}
+			logger.Fatalf("Unable to fetch installed packages: %v", err)
 		}
 		displayText = "Installed packages:"
 	case 1:

--- a/googetdb/googetdb.go
+++ b/googetdb/googetdb.go
@@ -36,6 +36,9 @@ const (
 		?, ?, ?, ?)`
 )
 
+// nowFunc returns the current time; can be overridden in tests.
+var nowFunc = time.Now
+
 // GooDB is the googet database.
 type GooDB struct {
 	db *sql.DB
@@ -110,7 +113,7 @@ func (g *GooDB) addPkg(pkgState client.PackageState) error {
 
 	pkgState.InstalledApp.Name, pkgState.InstalledApp.Reg = system.AppAssociation(spec, pkgState.LocalPath)
 	if pkgState.InstallDate == 0 {
-		pkgState.InstallDate = time.Now().Unix()
+		pkgState.InstallDate = nowFunc().Unix()
 	}
 
 	tx, err := g.db.Begin()

--- a/googetdb/googetdb.go
+++ b/googetdb/googetdb.go
@@ -24,7 +24,9 @@ import (
 	"time"
 
 	"github.com/google/googet/v2/client"
+	"github.com/google/googet/v2/settings"
 	"github.com/google/googet/v2/system"
+	"github.com/google/logger"
 
 	_ "modernc.org/sqlite" // Import the SQLite driver (unnamed)
 )
@@ -107,7 +109,9 @@ func (g *GooDB) addPkg(pkgState client.PackageState) error {
 	spec := pkgState.PackageSpec
 
 	pkgState.InstalledApp.Name, pkgState.InstalledApp.Reg = system.AppAssociation(spec, pkgState.LocalPath)
-	pkgState.InstallDate = time.Now().Unix()
+	if pkgState.InstallDate == 0 {
+		pkgState.InstallDate = time.Now().Unix()
+	}
 
 	tx, err := g.db.Begin()
 	if err != nil {
@@ -200,4 +204,57 @@ func (g *GooDB) FetchPkgs(pkgName string) (client.GooGetState, error) {
 	}
 
 	return state, nil
+}
+
+// readState reads the JSON installed package state from the given path,
+// retrying with a .bak extension if the first read fails.
+//
+// Deprecated: Use the googet.db sqlite database instead.
+func readState(sf string) (client.GooGetState, error) {
+	state, err := readStateFromPath(sf)
+	if err != nil {
+		sfNotExist := os.IsNotExist(err)
+		state, err = readStateFromPath(sf + ".bak")
+		if sfNotExist && os.IsNotExist(err) {
+			logger.Info("No state file found, assuming no packages installed.")
+			return client.GooGetState{}, nil
+		}
+	}
+	return state, err
+}
+
+// readStateFromPath is a helper function for readState.
+func readStateFromPath(sf string) (client.GooGetState, error) {
+	var s client.GooGetState
+	b, err := os.ReadFile(sf)
+	if err != nil {
+		return s, err
+	}
+	return s, json.Unmarshal(b, &s)
+}
+
+// Exists returns true if the database file already exists.
+func Exists(dbFile string) bool {
+	_, err := os.Stat(dbFile)
+	return !errors.Is(err, os.ErrNotExist)
+}
+
+// CreateIfMissing creates a new database file at the given path, seeding it
+// with the contents of the old JSON state file if it exists.
+func CreateIfMissing(dbFile string) error {
+	if Exists(dbFile) {
+		return nil
+	}
+	fmt.Println("Creating Googet DB and converting state file...")
+	db, err := NewDB(dbFile)
+	if err != nil {
+		return fmt.Errorf("unable to create initial db file: %v", err)
+	}
+	defer db.Close()
+	// If state file still exists, then convert.
+	state, err := readState(settings.StateFile())
+	if err != nil {
+		return fmt.Errorf("could not read state file: %v", err)
+	}
+	return db.WriteStateToDB(state)
 }

--- a/googetdb/googetdb_test.go
+++ b/googetdb/googetdb_test.go
@@ -95,6 +95,7 @@ func TestWriteStateToDBPreservesExistingTimestamps(t *testing.T) {
 	}
 	// Update the packages in the db.
 	nowFunc = func() time.Time { return time.Unix(175000000, 0) }
+	t.Cleanup(func() { nowFunc = time.Now })
 	s = client.GooGetState{
 		client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "test2", Version: "2"}},
 		client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "test4", Version: "3"}},

--- a/googetdb/googetdb_test.go
+++ b/googetdb/googetdb_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package googetdb
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/googet/v2/client"
 	"github.com/google/googet/v2/goolib"
+	"github.com/google/googet/v2/settings"
 )
 
 func TestConvertStatetoDB(t *testing.T) {
@@ -47,7 +49,6 @@ func TestConvertStatetoDB(t *testing.T) {
 	if !cmp.Equal(s, pkgs, cmpopts.IgnoreFields(client.PackageState{}, "InstallDate")) {
 		t.Errorf("GetPackageState did not return expected result, want: %#v, got: %#v", pkgs, s)
 	}
-	os.Remove("state.db")
 }
 
 func TestRemovePackage(t *testing.T) {
@@ -74,5 +75,80 @@ func TestRemovePackage(t *testing.T) {
 		fmt.Println(diff)
 		t.Errorf("GetPackageState did not return expected result, want: %#v, got: %#v", pkgs, s)
 	}
-	os.Remove("state.db")
+}
+
+func TestCreateIfMissing(t *testing.T) {
+	for _, tc := range []struct {
+		desc      string             // description of test case
+		initialDB client.GooGetState // initial contents of db file
+		stateFile client.GooGetState // initial contents of state file
+		want      client.GooGetState // expected db contents after call
+	}{
+		{
+			desc: "no-db-but-existing-state-file",
+			stateFile: client.GooGetState{
+				client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "test1"}, InstallDate: 1754021224},
+				client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "test2"}, InstallDate: 1735569000},
+			},
+			want: client.GooGetState{
+				client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "test1"}, InstallDate: 1754021224},
+				client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "test2"}, InstallDate: 1735569000},
+			},
+		},
+		{
+			desc: "existing-db-and-state-file",
+			initialDB: client.GooGetState{
+				client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "test1"}, InstallDate: 1754021224},
+				client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "test2"}, InstallDate: 1735569000},
+			},
+			stateFile: client.GooGetState{
+				client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "ignore3"}, InstallDate: 1625425200},
+				client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "ignore4"}, InstallDate: 1698717600},
+			},
+			want: client.GooGetState{
+				client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "test1"}, InstallDate: 1754021224},
+				client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "test2"}, InstallDate: 1735569000},
+			},
+		},
+		{
+			desc: "no-db-and-no-state-file",
+			want: client.GooGetState{},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			settings.Initialize(t.TempDir(), false)
+			dbFile := settings.DBFile()
+			if len(tc.initialDB) > 0 {
+				db, err := NewDB(dbFile)
+				if err != nil {
+					t.Fatalf("NewDB(%v): %v", dbFile, err)
+				}
+				if err := db.WriteStateToDB(tc.initialDB); err != nil {
+					t.Fatalf("WriteStateToDB: %v", err)
+				}
+				db.Close()
+			}
+			if len(tc.stateFile) > 0 {
+				b, err := json.Marshal(tc.stateFile)
+				if err != nil {
+					t.Fatalf("json.Marshal(%v): %v", tc.stateFile, err)
+				}
+				os.WriteFile(settings.StateFile(), b, 0664)
+			}
+			if err := CreateIfMissing(dbFile); err != nil {
+				t.Fatalf("CreateIfMissing(%v): %v", dbFile, err)
+			}
+			db, err := NewDB(dbFile)
+			if err != nil {
+				t.Fatalf("NewDB(%v): %v", dbFile, err)
+			}
+			pkgs, err := db.FetchPkgs("")
+			if err != nil {
+				t.Fatalf("Unable to fetch packages: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, pkgs, cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("FetchPkgs got unexpected diff (-want +got):\n%v", diff)
+			}
+		})
+	}
 }

--- a/googetdb/googetdb_test.go
+++ b/googetdb/googetdb_test.go
@@ -84,6 +84,7 @@ func TestWriteStateToDBPreservesExistingTimestamps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewDB(%v): %v", dbFile, err)
 	}
+	defer db.Close()
 	// Set the initial package state.
 	s := client.GooGetState{
 		client.PackageState{PackageSpec: &goolib.PkgSpec{Name: "test1", Version: "1"}, InstallDate: 123456789},

--- a/googetdb/googetdb_test.go
+++ b/googetdb/googetdb_test.go
@@ -142,6 +142,7 @@ func TestCreateIfMissing(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewDB(%v): %v", dbFile, err)
 			}
+			defer db.Close()
 			pkgs, err := db.FetchPkgs("")
 			if err != nil {
 				t.Fatalf("Unable to fetch packages: %v", err)


### PR DESCRIPTION
* Move all of the conversion code into CreateIfMissing function in googetdb.
* Move readState out of package main and into googetdb.
* Delete the unused writeState function.
* In googet.go, always obtain lock before attempting conversion. If database already exists, allow "googet installed" to run. Otherwise "googet installed" will grab a lock and try to convert the state file into a database.
* Move conversion to after logging has been setup so that we can properly log errors.
* In addPkg, update the InstallDate to the current time only if it is the zero value. This allows us to preserve install dates from existing state files that are converted. But, more importantly, also means that we preserve install dates when we read the entire package state and then write it back out.
