### PR TITLE
Move info function from package main into goolib.

### DIFF
--- a/googet.go
+++ b/googet.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -36,7 +35,6 @@ import (
 	"github.com/google/googet/v2/settings"
 	"github.com/google/logger"
 	"github.com/google/subcommands"
-	"github.com/olekukonko/tablewriter"
 	"gopkg.in/yaml.v3"
 )
 
@@ -272,75 +270,6 @@ func confirmation(msg string) bool {
 	fmt.Scanln(&c)
 	c = strings.ToLower(c)
 	return c == "y" || c == "yes"
-}
-
-func info(ps *goolib.PkgSpec, r string) {
-	fmt.Println()
-
-	pkgInfo := []struct {
-		name, value string
-	}{
-		{"Name", ps.Name},
-		{"Arch", ps.Arch},
-		{"Version", ps.Version},
-		{"Repo", path.Base(r)},
-		{"Authors", ps.Authors},
-		{"Owners", ps.Owners},
-		{"Source", ps.Source},
-		{"Description", ps.Description},
-		{"Dependencies", ""},
-		{"ReleaseNotes", ""},
-	}
-	var w int
-	for _, pi := range pkgInfo {
-		if len(pi.name) > w {
-			w = len(pi.name)
-		}
-	}
-	wf := fmt.Sprintf("%%-%vs: %%s\n", w+1)
-
-	for _, pi := range pkgInfo {
-		if pi.name == "Dependencies" {
-			var deps []string
-			for p, v := range ps.PkgDependencies {
-				deps = append(deps, p+" "+v)
-			}
-			if len(deps) == 0 {
-				fmt.Printf(wf, pi.name, "None")
-			} else {
-				fmt.Printf(wf, pi.name, deps[0])
-				for _, l := range deps[1:] {
-					fmt.Printf(wf, "", l)
-				}
-			}
-		} else if pi.name == "ReleaseNotes" && ps.ReleaseNotes != nil {
-			sl, _ := tablewriter.WrapString(ps.ReleaseNotes[0], 76-w)
-			fmt.Printf(wf, pi.name, sl[0])
-			for _, l := range sl[1:] {
-				fmt.Printf(wf, "", l)
-			}
-			for _, l := range ps.ReleaseNotes[1:] {
-				sl, _ := tablewriter.WrapString(l, 76-w)
-				fmt.Printf(wf, "", sl[0])
-				for _, l := range sl[1:] {
-					fmt.Printf(wf, "", l)
-				}
-			}
-		} else {
-			cl := strings.Split(strings.TrimSpace(pi.value), "\n")
-			sl, _ := tablewriter.WrapString(cl[0], 76-w)
-			fmt.Printf(wf, pi.name, sl[0])
-			for _, l := range sl[1:] {
-				fmt.Printf(wf, "", l)
-			}
-			for _, l := range cl[1:] {
-				sl, _ := tablewriter.WrapString(l, 76-w)
-				for _, l := range sl {
-					fmt.Printf(wf, "", l)
-				}
-			}
-		}
-	}
 }
 
 func rotateLog(logPath string, ls int64) error {

--- a/googet_available.go
+++ b/googet_available.go
@@ -120,7 +120,8 @@ func repo(pi goolib.PackageInfo, rm client.RepoMap) {
 	for r, repo := range rm {
 		for _, p := range repo.Packages {
 			if p.PackageSpec.Name == pi.Name && p.PackageSpec.Arch == pi.Arch && p.PackageSpec.Version == pi.Ver {
-				info(p.PackageSpec, r)
+				fmt.Println()
+				p.PackageSpec.PrettyPrint(os.Stdout, r)
 				return
 			}
 		}

--- a/googet_installed.go
+++ b/googet_installed.go
@@ -166,7 +166,8 @@ func (cmd *installedCmd) formatJSON(state client.GooGetState) subcommands.ExitSt
 func local(pi goolib.PackageInfo, state client.GooGetState) {
 	for _, p := range state {
 		if p.Match(pi) {
-			info(p.PackageSpec, "installed")
+			fmt.Println()
+			p.PackageSpec.PrettyPrint(os.Stdout, "installed")
 			return
 		}
 	}


### PR DESCRIPTION
The info() function in googet.go is used by the "installed" and "available" subcommands to print out info about a PkgSpec. This moves that code into the goolib package, next to the PkgSpec definition. Cleaned it up, made it a method on PkgSpec, and renamed it to PrettyPrint. Added tests. The only difference in the old output vs the new output is that listed dependencies are now printed in a deterministic order.