### PR TITLE
Fix replaces logic and moves db actions to more timely execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/google/googet/v2
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.24.0
 
 require (
 	cloud.google.com/go/storage v1.28.1

--- a/googet_install.go
+++ b/googet_install.go
@@ -149,8 +149,7 @@ func (i *installer) installFromFile(path string) error {
 		fmt.Printf("Not installing %s...\n", base)
 		return nil
 	}
-	err := install.FromDisk(path, i.cache, i.dbOnly, i.shouldReinstall, i.db)
-	if err != nil {
+	if err := install.FromDisk(path, i.cache, i.dbOnly, i.shouldReinstall, i.db); err != nil {
 		return fmt.Errorf("installing %s: %v", path, err)
 	}
 	return nil

--- a/googet_install.go
+++ b/googet_install.go
@@ -149,17 +149,9 @@ func (i *installer) installFromFile(path string) error {
 		fmt.Printf("Not installing %s...\n", base)
 		return nil
 	}
-	// Pull the whole state to check against local pkgspec.
-	state, err := i.db.FetchPkgs("")
-	if err != nil {
-		return fmt.Errorf("unable to fetch installed packages: %v", err)
-	}
-	insPkg, err := install.FromDisk(path, i.cache, &state, i.dbOnly, i.shouldReinstall)
+	err := install.FromDisk(path, i.cache, i.dbOnly, i.shouldReinstall, i.db)
 	if err != nil {
 		return fmt.Errorf("installing %s: %v", path, err)
-	}
-	if err := i.db.WriteStateToDB(insPkg); err != nil {
-		return fmt.Errorf("writing state database: %v", err)
 	}
 	return nil
 }
@@ -199,18 +191,14 @@ func (i *installer) installFromRepo(ctx context.Context, name string, archs []st
 	if err != nil {
 		return fmt.Errorf("error finding %s.%s.%s in repo: %v", pi.Name, pi.Arch, pi.Ver, err)
 	}
-	state, err := i.db.FetchPkgs("")
-	if err != nil {
-		return fmt.Errorf("unable to fetch installed packages: %v", err)
-	}
-	if ni, err := install.NeedsInstallation(pi, state); err != nil {
+	if ni, err := install.NeedsInstallation(pi, i.db); err != nil {
 		return err
 	} else if !ni {
 		fmt.Printf("%s.%s.%s or a newer version is already installed on the system\n", pi.Name, pi.Arch, pi.Ver)
 		return nil
 	}
 	if i.confirm {
-		b, err := enumerateDeps(pi, i.repoMap, r, archs, state)
+		b, err := i.enumerateDeps(pi, r, archs)
 		if err != nil {
 			return err
 		}
@@ -219,12 +207,10 @@ func (i *installer) installFromRepo(ctx context.Context, name string, archs []st
 			return nil
 		}
 	}
-	if err := install.FromRepo(ctx, pi, r, i.cache, i.repoMap, archs, &state, i.dbOnly, i.downloader); err != nil {
+	if err := install.FromRepo(ctx, pi, r, i.cache, i.repoMap, archs, i.dbOnly, i.downloader, i.db); err != nil {
 		return fmt.Errorf("installing %s.%s.%s: %v", pi.Name, pi.Arch, pi.Ver, err)
 	}
-	if err := i.db.WriteStateToDB(state); err != nil {
-		return fmt.Errorf("writing state file: %v", err)
-	}
+
 	return nil
 }
 
@@ -245,15 +231,15 @@ func (i *installer) reinstall(ctx context.Context, pi goolib.PackageInfo, ps cli
 	return nil
 }
 
-func enumerateDeps(pi goolib.PackageInfo, rm client.RepoMap, r string, archs []string, state client.GooGetState) (*bytes.Buffer, error) {
-	dl, err := install.ListDeps(pi, rm, r, archs)
+func (i *installer) enumerateDeps(pi goolib.PackageInfo, r string, archs []string) (*bytes.Buffer, error) {
+	dl, err := install.ListDeps(pi, i.repoMap, r, archs)
 	if err != nil {
 		return nil, fmt.Errorf("error listing dependencies for %s.%s.%s: %v", pi.Name, pi.Arch, pi.Ver, err)
 	}
 	var b bytes.Buffer
 	fmt.Fprintln(&b, "The following packages will be installed:")
 	for _, di := range dl {
-		ni, err := install.NeedsInstallation(di, state)
+		ni, err := install.NeedsInstallation(di, i.db)
 		if err != nil {
 			return nil, err
 		}

--- a/googet_install_test.go
+++ b/googet_install_test.go
@@ -194,12 +194,12 @@ func TestInstall(t *testing.T) {
 			args: []string{"B"},
 			state: client.GooGetState{
 				{PackageSpec: &goolib.PkgSpec{Name: "A", Arch: "noarch", Version: "5"}},
-				{PackageSpec: &goolib.PkgSpec{Name: "C", Arch: "noarch", Version: "3", PkgDependencies: map[string]string{"A": "2"}}},
+				{PackageSpec: &goolib.PkgSpec{Name: "C", Arch: "noarch", Version: "3", PkgDependencies: map[string]string{"A": "5"}}},
 			},
 			packages: []goolib.PkgSpec{
 				{Name: "A", Arch: "noarch", Version: "5"},
 				{Name: "B", Arch: "noarch", Version: "2", Replaces: []string{"A.noarch.3"}},
-				{Name: "C", Arch: "noarch", Version: "3", PkgDependencies: map[string]string{"A": "2"}},
+				{Name: "C", Arch: "noarch", Version: "3", PkgDependencies: map[string]string{"A": "5"}},
 			},
 			wantInstalled: []string{"B.noarch.2"},
 			wantState:     []string{"B.noarch.2"},

--- a/googet_install_test.go
+++ b/googet_install_test.go
@@ -176,6 +176,34 @@ func TestInstall(t *testing.T) {
 			wantInstalled: []string{"A.noarch.1"},
 			wantState:     []string{"A.noarch.1", "B.noarch.2", "C.noarch.3"},
 		},
+		{
+			desc: "remove-replaced-package",
+			args: []string{"B"},
+			state: client.GooGetState{
+			{PackageSpec: &goolib.PkgSpec{Name: "A", Arch: "noarch", Version: "5"}},
+			},
+			packages: []goolib.PkgSpec{
+				{Name: "A", Arch: "noarch", Version: "5"},
+				{Name: "B", Arch: "noarch", Version: "2", Replaces: []string{"A.noarch.3"}},
+			},
+			wantInstalled: []string{"B.noarch.2"},
+			wantState:     []string{"B.noarch.2"},
+		},
+		{
+			desc: "remove-replaced-package-with-deps",
+			args: []string{"B"},
+			state: client.GooGetState{
+				{PackageSpec: &goolib.PkgSpec{Name: "A", Arch: "noarch", Version: "5"}},
+				{PackageSpec: &goolib.PkgSpec{Name: "C", Arch: "noarch", Version: "3", PkgDependencies: map[string]string{"A": "2"}}},
+			},
+			packages: []goolib.PkgSpec{
+				{Name: "A", Arch: "noarch", Version: "5"},
+				{Name: "B", Arch: "noarch", Version: "2", Replaces: []string{"A.noarch.3"}},
+				{Name: "C", Arch: "noarch", Version: "3", PkgDependencies: map[string]string{"A": "2"}},
+			},
+			wantInstalled: []string{"B.noarch.2"},
+			wantState:     []string{"B.noarch.2"},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			// Set up the installer.

--- a/googet_install_test.go
+++ b/googet_install_test.go
@@ -180,7 +180,7 @@ func TestInstall(t *testing.T) {
 			desc: "remove-replaced-package",
 			args: []string{"B"},
 			state: client.GooGetState{
-			{PackageSpec: &goolib.PkgSpec{Name: "A", Arch: "noarch", Version: "5"}},
+				{PackageSpec: &goolib.PkgSpec{Name: "A", Arch: "noarch", Version: "5"}},
 			},
 			packages: []goolib.PkgSpec{
 				{Name: "A", Arch: "noarch", Version: "5"},

--- a/googet_remove.go
+++ b/googet_remove.go
@@ -68,7 +68,7 @@ func (cmd *removeCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...int
 			logger.Errorf("Package %q not installed, cannot remove.", arg)
 			continue
 		}
-		pi = goolib.PkgNameSplit(ps.PackageSpec.Name + "." + ps.PackageSpec.Arch)
+		pi = goolib.PackageInfo{Name: ps.PackageSpec.Name, Arch: ps.PackageSpec.Arch}
 		deps, dl := remove.EnumerateDeps(pi, db)
 		if settings.Confirm {
 			var b bytes.Buffer

--- a/googet_remove.go
+++ b/googet_remove.go
@@ -60,7 +60,6 @@ func (cmd *removeCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...int
 	}
 	for _, arg := range flags.Args() {
 		pi := goolib.PkgNameSplit(arg)
-		var ins []string
 		ps, err := db.FetchPkg(pi.Name)
 		if err != nil {
 			logger.Fatal(err)
@@ -69,10 +68,7 @@ func (cmd *removeCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...int
 			logger.Errorf("Package %q not installed, cannot remove.", arg)
 			continue
 		}
-		if ps.Match(pi) {
-			ins = append(ins, ps.PackageSpec.Name+"."+ps.PackageSpec.Arch)
-		}
-		pi = goolib.PkgNameSplit(ins[0])
+		pi = goolib.PkgNameSplit(ps.PackageSpec.Name+"."+ps.PackageSpec.Arch)
 		deps, dl := remove.EnumerateDeps(pi, db)
 		if settings.Confirm {
 			var b bytes.Buffer

--- a/googet_remove.go
+++ b/googet_remove.go
@@ -58,28 +58,22 @@ func (cmd *removeCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...int
 	if err != nil {
 		logger.Fatal(err)
 	}
-	state, err := db.FetchPkgs("")
-	if err != nil {
-		logger.Fatalf("Unable to fetch installed pacakges: %v", err)
-	}
 	for _, arg := range flags.Args() {
 		pi := goolib.PkgNameSplit(arg)
 		var ins []string
-		for _, ps := range state {
-			if ps.Match(pi) {
-				ins = append(ins, ps.PackageSpec.Name+"."+ps.PackageSpec.Arch)
-			}
+		ps, err := db.FetchPkg(pi.Name)
+		if err != nil {
+			logger.Fatal(err)
 		}
-		if len(ins) == 0 {
+		if ps.PackageSpec == nil {
 			logger.Errorf("Package %q not installed, cannot remove.", arg)
 			continue
 		}
-		if len(ins) > 1 {
-			fmt.Fprintf(os.Stderr, "More than one %s installed, chose one of:\n%s\n", arg, ins)
-			return subcommands.ExitFailure
+		if ps.Match(pi) {
+			ins = append(ins, ps.PackageSpec.Name+"."+ps.PackageSpec.Arch)
 		}
 		pi = goolib.PkgNameSplit(ins[0])
-		deps, dl := remove.EnumerateDeps(pi, state)
+		deps, dl := remove.EnumerateDeps(pi, db)
 		if settings.Confirm {
 			var b bytes.Buffer
 			fmt.Fprintln(&b, "The following packages will be removed:")
@@ -94,7 +88,7 @@ func (cmd *removeCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...int
 		}
 		fmt.Printf("Removing %s and all dependencies...\n", pi.Name)
 
-		if err = remove.All(ctx, pi, deps, &state, cmd.dbOnly, downloader); err != nil {
+		if err = remove.All(ctx, pi, deps, cmd.dbOnly, downloader, db); err != nil {
 			logger.Errorf("error removing %s, %v", arg, err)
 			exitCode = subcommands.ExitFailure
 			continue

--- a/googet_remove.go
+++ b/googet_remove.go
@@ -68,7 +68,7 @@ func (cmd *removeCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...int
 			logger.Errorf("Package %q not installed, cannot remove.", arg)
 			continue
 		}
-		pi = goolib.PkgNameSplit(ps.PackageSpec.Name+"."+ps.PackageSpec.Arch)
+		pi = goolib.PkgNameSplit(ps.PackageSpec.Name + "." + ps.PackageSpec.Arch)
 		deps, dl := remove.EnumerateDeps(pi, db)
 		if settings.Confirm {
 			var b bytes.Buffer

--- a/googet_update.go
+++ b/googet_update.go
@@ -99,15 +99,11 @@ func (cmd *updateCmd) Execute(ctx context.Context, _ *flag.FlagSet, _ ...interfa
 		if err != nil {
 			logger.Errorf("Error finding repo: %v.", err)
 		}
-		if err := install.FromRepo(ctx, pi, r, cache, rm, settings.Archs, &state, cmd.dbOnly, downloader); err != nil {
+		if err := install.FromRepo(ctx, pi, r, cache, rm, settings.Archs, cmd.dbOnly, downloader, db); err != nil {
 			logger.Errorf("Error updating %s %s %s: %v", pi.Arch, pi.Name, pi.Ver, err)
 			exitCode = subcommands.ExitFailure
 			continue
 		}
-	}
-
-	if err := db.WriteStateToDB(state); err != nil {
-		logger.Fatalf("Error writing state db: %v", err)
 	}
 
 	return exitCode

--- a/googetdb/googetdb.go
+++ b/googetdb/googetdb.go
@@ -100,7 +100,7 @@ func (g *GooDB) WriteStateToDB(gooState client.GooGetState) error {
 		if pkgState.PackageSpec == nil {
 			continue
 		}
-		err := g.addPkg(pkgState)
+		err := g.AddPkg(pkgState)
 		if err != nil {
 			return err
 		}
@@ -108,7 +108,8 @@ func (g *GooDB) WriteStateToDB(gooState client.GooGetState) error {
 	return nil
 }
 
-func (g *GooDB) addPkg(pkgState client.PackageState) error {
+// AddPkg adds a single package to the googet database
+func (g *GooDB) AddPkg(pkgState client.PackageState) error {
 	spec := pkgState.PackageSpec
 
 	pkgState.InstalledApp.Name, pkgState.InstalledApp.Reg = system.AppAssociation(spec, pkgState.LocalPath)

--- a/install/install.go
+++ b/install/install.go
@@ -231,16 +231,10 @@ func FromDisk(pkgPath, cache string, dbOnly, shouldReinstall bool, db *googetdb.
 	if shouldReinstall {
 		logger.Infof("Reinstallation of %q, version %q completed", zs.Name, zs.Version)
 		fmt.Printf("Reinstallation of %s completed\n", zs.Name)
-		return db.AddPkg(client.PackageState{
-			LocalPath:      dst,
-			PackageSpec:    zs,
-			InstalledFiles: insFiles,
-		})
+	} else {
+		logger.Infof("Installation of %q, version %q completed", zs.Name, zs.Version)
+		fmt.Printf("Installation of %s completed\n", zs.Name)
 	}
-
-	logger.Infof("Installation of %q, version %q completed", zs.Name, zs.Version)
-	fmt.Printf("Installation of %s completed\n", zs.Name)
-
 	return db.AddPkg(client.PackageState{
 		LocalPath:      dst,
 		PackageSpec:    zs,

--- a/install/install.go
+++ b/install/install.go
@@ -103,7 +103,8 @@ func installDeps(ctx context.Context, ps *goolib.PkgSpec, cache string, rm clien
 	// Check for and install any dependencies.
 	for p, ver := range ps.PkgDependencies {
 		pi := goolib.PkgNameSplit(p)
-		ok, err := minInstalled(goolib.PackageInfo{Name: pi.Name, Arch: pi.Arch, Ver: ver}, db); if err != nil {
+		ok, err := minInstalled(goolib.PackageInfo{Name: pi.Name, Arch: pi.Arch, Ver: ver}, db)
+		if err != nil {
 			return err
 		} else if ok {
 			logger.Infof("Dependency met: %s.%s with version greater than %s installed", pi.Name, pi.Arch, ver)

--- a/install/install_test.go
+++ b/install/install_test.go
@@ -72,11 +72,7 @@ func TestMinInstalled(t *testing.T) {
 		{"baz_pkg", "noarch", false},
 	}
 	for _, tt := range table {
-		pkg, err := db.FetchPkg(tt.pkg)
-		if err != nil {
-			t.Fatalf("error checking minAvailable: %v", err)
-		}
-		ma, err := minInstalled(goolib.PackageInfo{Name: tt.pkg, Arch: tt.arch, Ver: "1.0.0@1"}, &pkg)
+		ma, err := minInstalled(goolib.PackageInfo{Name: tt.pkg, Arch: tt.arch, Ver: "1.0.0@1"}, db)
 		if err != nil {
 			t.Fatalf("error checking minAvailable: %v", err)
 		}

--- a/install/install_test.go
+++ b/install/install_test.go
@@ -25,8 +25,10 @@ import (
 	"testing"
 
 	"github.com/google/googet/v2/client"
+	"github.com/google/googet/v2/googetdb"
 	"github.com/google/googet/v2/goolib"
 	"github.com/google/googet/v2/oswrap"
+	"github.com/google/googet/v2/settings"
 	"github.com/google/logger"
 )
 
@@ -35,6 +37,7 @@ func init() {
 }
 
 func TestMinInstalled(t *testing.T) {
+	settings.Initialize(t.TempDir(), false)
 	state := []client.PackageState{
 		{
 			PackageSpec: &goolib.PkgSpec{
@@ -51,7 +54,12 @@ func TestMinInstalled(t *testing.T) {
 			},
 		},
 	}
-
+	db, err := googetdb.NewDB(settings.DBFile())
+	if err != nil {
+		t.Fatalf("googetdb.NewDB: %v", err)
+	}
+	defer db.Close()
+	db.WriteStateToDB(state)
 	table := []struct {
 		pkg, arch string
 		ins       bool
@@ -64,7 +72,11 @@ func TestMinInstalled(t *testing.T) {
 		{"baz_pkg", "noarch", false},
 	}
 	for _, tt := range table {
-		ma, err := minInstalled(goolib.PackageInfo{Name: tt.pkg, Arch: tt.arch, Ver: "1.0.0@1"}, state)
+		pkg, err := db.FetchPkg(tt.pkg)
+		if err != nil {
+			t.Fatalf("error checking minAvailable: %v", err)
+		}
+		ma, err := minInstalled(goolib.PackageInfo{Name: tt.pkg, Arch: tt.arch, Ver: "1.0.0@1"}, &pkg)
 		if err != nil {
 			t.Fatalf("error checking minAvailable: %v", err)
 		}
@@ -75,6 +87,7 @@ func TestMinInstalled(t *testing.T) {
 }
 
 func TestNeedsInstallation(t *testing.T) {
+	settings.Initialize(t.TempDir(), false)
 	state := []client.PackageState{
 		{
 			PackageSpec: &goolib.PkgSpec{
@@ -98,7 +111,12 @@ func TestNeedsInstallation(t *testing.T) {
 			},
 		},
 	}
-
+	db, err := googetdb.NewDB(settings.DBFile())
+	if err != nil {
+		t.Fatalf("googetdb.NewDB: %v", err)
+	}
+	defer db.Close()
+	db.WriteStateToDB(state)
 	table := []struct {
 		pkg string
 		ver string
@@ -110,7 +128,7 @@ func TestNeedsInstallation(t *testing.T) {
 		{"pkg", "1.0.0@1", true},      // not installed
 	}
 	for _, tt := range table {
-		ins, err := NeedsInstallation(goolib.PackageInfo{Name: tt.pkg, Arch: "noarch", Ver: tt.ver}, state)
+		ins, err := NeedsInstallation(goolib.PackageInfo{Name: tt.pkg, Arch: "noarch", Ver: tt.ver}, db)
 		if err != nil {
 			t.Fatalf("Error checking NeedsInstallation: %v", err)
 		}

--- a/remove/remove_test.go
+++ b/remove/remove_test.go
@@ -37,7 +37,6 @@ func init() {
 }
 
 func TestUninstallPkg(t *testing.T) {
-	// Set up the installer.
 	settings.Initialize(t.TempDir(), false)
 	src, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -96,7 +95,16 @@ func TestUninstallPkg(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	st := &client.GooGetState{
+	d, err := client.NewDownloader("")
+	if err != nil {
+		t.Fatalf("NewDownloader: %v", err)
+	}
+	db, err := googetdb.NewDB(settings.DBFile())
+	if err != nil {
+		t.Fatalf("googetdb.NewDB: %v", err)
+	}
+	defer db.Close()
+	db.WriteStateToDB(client.GooGetState{
 		client.PackageState{
 			PackageSpec: &goolib.PkgSpec{
 				Name: "foo",
@@ -110,17 +118,7 @@ func TestUninstallPkg(t *testing.T) {
 			},
 			LocalPath: f.Name(),
 		},
-	}
-	d, err := client.NewDownloader("")
-	if err != nil {
-		t.Fatalf("NewDownloader: %v", err)
-	}
-	db, err := googetdb.NewDB(settings.DBFile())
-	if err != nil {
-		t.Fatalf("googetdb.NewDB: %v", err)
-	}
-	defer db.Close()
-	db.WriteStateToDB(*st)
+	})
 	if err := uninstallPkg(context.Background(), goolib.PackageInfo{Name: "foo"}, false, d, db); err != nil {
 		t.Fatalf("Error running uninstallPkg: %v", err)
 	}


### PR DESCRIPTION
- Remove the passing of state in favor of passing the db object
- Add/Remove packages as they finish uninstalling, rather than batch at the end
- This fixes replaces logic since we aren't just slamming a new state file every time.