### PR TITLE
Get rid of the global deferredFuncs variable.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/google/googet/v2
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.24
 
 require (
 	cloud.google.com/go/storage v1.28.1


### PR DESCRIPTION
This changes obtainLock (and the underlying platform-specific lock functions) to return a cleanup function, rather than having them add the cleanup to a global deferredFuncs variable. The returned cleanup function is deferred using normal Go idioms. As part of this change, we move most of the code of main into a separate run function and call os.Exit in at most one place in order to ensure that deferred funcs are run before the program exits. This also means converting logger.Fatal calls to logger.Error instead, since logger.Fatal immediately calls os.Exit, circumventing any defers.