### PR TITLE
Correct `googet check` exit code

### DIFF
--- a/cli/check/check.go
+++ b/cli/check/check.go
@@ -55,7 +55,7 @@ func (cmd *checkCmd) SetFlags(f *flag.FlagSet) {
 }
 
 func (cmd *checkCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	exitCode := subcommands.ExitFailure
+	exitCode := subcommands.ExitSuccess
 	cache := settings.CacheDir()
 	db, err := googetdb.NewDB(settings.DBFile())
 	if err != nil {


### PR DESCRIPTION
Googet check is incorrectly setting the exit code to 1 even in successful runs, this should allow it to exit 0.