### PR TITLE
Replace logger.Fatal with logger.Error + return subcommands.ExitFailure

### DIFF
--- a/cli/available/available.go
+++ b/cli/available/available.go
@@ -71,15 +71,18 @@ func (cmd *availableCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...inte
 
 	repos, err := repo.BuildSources(cmd.sources)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to initialize repos: %v", err)
+		return subcommands.ExitFailure
 	}
 	if repos == nil {
-		logger.Fatal("No repos defined, create a .repo file or pass using the -sources flag.")
+		logger.Error("No repos defined, create a .repo file or pass using the -sources flag.")
+		return subcommands.ExitFailure
 	}
 
 	downloader, err := client.NewDownloader(settings.ProxyServer)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to initialize downloader: %v", err)
+		return subcommands.ExitFailure
 	}
 
 	m := make(map[string][]string)

--- a/cli/check/check.go
+++ b/cli/check/check.go
@@ -59,20 +59,24 @@ func (cmd *checkCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfac
 	cache := settings.CacheDir()
 	db, err := googetdb.NewDB(settings.DBFile())
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to open database: %v", err)
+		return subcommands.ExitFailure
 	}
 	defer db.Close()
 	state, err := db.FetchPkgs("")
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed fetching installed packages: %v", err)
+		return subcommands.ExitFailure
 	}
 	downloader, err := client.NewDownloader(settings.ProxyServer)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to initialize downloader: %v", err)
+		return subcommands.ExitFailure
 	}
 	repos, err := repo.BuildSources(cmd.sources)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to initialize repos: %v", err)
+		return subcommands.ExitFailure
 	}
 
 	rm := downloader.AvailableVersions(ctx, repos, cache, settings.CacheLife)

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -56,15 +56,18 @@ func (cmd *downloadCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...i
 	}
 	repos, err := repo.BuildSources(cmd.sources)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to initialize repos: %v", err)
+		return subcommands.ExitFailure
 	}
 	if repos == nil {
-		logger.Fatal("No repos defined, create a .repo file or pass using the -sources flag.")
+		logger.Error("No repos defined, create a .repo file or pass using the -sources flag.")
+		return subcommands.ExitFailure
 	}
 
 	downloader, err := client.NewDownloader(settings.ProxyServer)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to initialize downloader: %v", err)
+		return subcommands.ExitFailure
 	}
 
 	rm := downloader.AvailableVersions(ctx, repos, settings.CacheDir(), settings.CacheLife)
@@ -74,7 +77,8 @@ func (cmd *downloadCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...i
 	if dir == "" {
 		dir, err = os.Getwd()
 		if err != nil {
-			logger.Fatal(err)
+			logger.Errorf("Failed to get current directory and -download_dir not specified: %v", err)
+			return subcommands.ExitFailure
 		}
 	}
 

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -69,13 +69,15 @@ func (cmd *installCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...an
 
 	db, err := googetdb.NewDB(settings.DBFile())
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to open database: %v", err)
+		return subcommands.ExitFailure
 	}
 	defer db.Close()
 
 	downloader, err := client.NewDownloader(settings.ProxyServer)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to initialize downloader: %v", err)
+		return subcommands.ExitFailure
 	}
 
 	i := &installer{
@@ -93,10 +95,12 @@ func (cmd *installCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...an
 	if !allFileGoos(flag.Args()) {
 		repos, err := repo.BuildSources(cmd.sources)
 		if err != nil {
-			logger.Fatal(err)
+			logger.Errorf("Failed to initialize repos: %v", err)
+			return subcommands.ExitFailure
 		}
 		if repos == nil {
-			logger.Fatal("No repos defined, create a .repo file or pass using the -sources flag.")
+			logger.Error("No repos defined, create a .repo file or pass using the -sources flag.")
+			return subcommands.ExitFailure
 		}
 		i.repoMap = i.downloader.AvailableVersions(ctx, repos, i.cache, settings.CacheLife)
 	}

--- a/cli/installed/installed.go
+++ b/cli/installed/installed.go
@@ -62,20 +62,23 @@ func (cmd *installedCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interf
 	var displayText string
 	db, err := googetdb.NewDB(settings.DBFile())
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to open database: %v", err)
+		return subcommands.ExitFailure
 	}
 	defer db.Close()
 	switch f.NArg() {
 	case 0:
 		state, err = db.FetchPkgs("")
 		if err != nil {
-			logger.Fatalf("Unable to fetch installed packages: %v", err)
+			logger.Errorf("Failed fetching installed packages: %v", err)
+			return subcommands.ExitFailure
 		}
 		displayText = "Installed packages:"
 	case 1:
 		state, err = db.FetchPkgs(f.Arg(0))
 		if err != nil {
-			logger.Fatalf("Unable to fetch installed packges: %v", err)
+			logger.Errorf("Failed fetching installed packages: %v", err)
+			return subcommands.ExitFailure
 		}
 		displayText = fmt.Sprintf("Installed packages matching %q:", f.Arg(0))
 		if len(state) == 0 {
@@ -140,7 +143,8 @@ func (cmd *installedCmd) formatSimple(state client.GooGetState, displayText stri
 func (cmd *installedCmd) formatJSON(state client.GooGetState) subcommands.ExitStatus {
 	marshaled, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
-		logger.Fatalf("marshaling error: %s", err)
+		logger.Errorf("marshaling error: %s", err)
+		return subcommands.ExitFailure
 	}
 	if string(marshaled) != "null" {
 		fmt.Println(string(marshaled))

--- a/cli/listrepos/listrepos.go
+++ b/cli/listrepos/listrepos.go
@@ -41,7 +41,8 @@ func (cmd *listReposCmd) SetFlags(f *flag.FlagSet) {}
 func (cmd *listReposCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	rfs, err := repo.ConfigFiles(settings.RepoDir())
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to read repo configs: %v", err)
+		return subcommands.ExitFailure
 	}
 	for _, rf := range rfs {
 		fmt.Println(rf.Path + ":")

--- a/cli/update/update.go
+++ b/cli/update/update.go
@@ -55,13 +55,15 @@ func (cmd *updateCmd) SetFlags(f *flag.FlagSet) {
 func (cmd *updateCmd) Execute(ctx context.Context, _ *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	db, err := googetdb.NewDB(settings.DBFile())
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to open database: %v", err)
+		return subcommands.ExitFailure
 	}
 	defer db.Close()
 	cache := settings.CacheDir()
 	state, err := db.FetchPkgs("")
 	if err != nil {
-		logger.Fatalf("Unable to fetch installed packges: %v", err)
+		logger.Errorf("Failed fetching installed packages: %v", err)
+		return subcommands.ExitFailure
 	}
 
 	if len(state) == 0 {
@@ -71,15 +73,18 @@ func (cmd *updateCmd) Execute(ctx context.Context, _ *flag.FlagSet, _ ...interfa
 
 	repos, err := repo.BuildSources(cmd.sources)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to initialize repos: %v", err)
+		return subcommands.ExitFailure
 	}
 	if repos == nil {
-		logger.Fatal("No repos defined, create a .repo file or pass using the -sources flag.")
+		logger.Error("No repos defined, create a .repo file or pass using the -sources flag.")
+		return subcommands.ExitFailure
 	}
 
 	downloader, err := client.NewDownloader(settings.ProxyServer)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to initialize downloader: %v", err)
+		return subcommands.ExitFailure
 	}
 
 	rm := downloader.AvailableVersions(ctx, repos, cache, settings.CacheLife)

--- a/cli/verify/verify.go
+++ b/cli/verify/verify.go
@@ -59,12 +59,14 @@ func (cmd *verifyCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...int
 
 	db, err := googetdb.NewDB(settings.DBFile())
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to open database: %v", err)
+		return subcommands.ExitFailure
 	}
 	defer db.Close()
 	downloader, err := client.NewDownloader(settings.ProxyServer)
 	if err != nil {
-		logger.Fatal(err)
+		logger.Errorf("Failed to initialize downloader: %v", err)
+		return subcommands.ExitFailure
 	}
 
 	for _, arg := range flags.Args() {


### PR DESCRIPTION
Get rid of most occurrences of logger.Fatal. These are bad because they immediately call `os.Exit(1)`, bypassing any clean up code (for example lock cleanup) that would have otherwise been executed before program exit.