### PR TITLE
Handle stale locks in system.ObtainLock.

### DIFF
--- a/googet.go
+++ b/googet.go
@@ -138,7 +138,7 @@ func run(ctx context.Context) int {
 		logger.Errorf("Failed admin check: %v", err)
 		return 1
 	}
-	cleanup, err := system.ObtainLock(settings.LockFile())
+	cleanup, err := system.ObtainLock(settings.LockFile(), settings.LockFileMaxAge)
 	if err != nil {
 		logger.Errorf("Failed to obtain lock: %v", err)
 		return 1

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -20,6 +20,8 @@ var (
 	// CacheLife is how long cached indexes are considered valid.
 	// The default value can be overridden by googet.conf.
 	CacheLife = 3 * time.Minute
+	// LockFileMaxAge is the maximum age of a lock file before it's considered stale.
+	LockFileMaxAge = 24 * time.Hour
 	// Archs is the list of valid arches for the system.
 	// Taken from googet.conf, or else derived from runtime.GOARCH.
 	Archs []string
@@ -76,6 +78,7 @@ func RepoDir() string {
 type conf struct {
 	Archs          []string
 	CacheLife      string
+	LockFileMaxAge string
 	ProxyServer    string
 	AllowUnsafeURL bool
 }
@@ -114,6 +117,13 @@ func readConf(filename string) {
 
 	if gc.CacheLife != "" {
 		CacheLife, err = time.ParseDuration(gc.CacheLife)
+		if err != nil {
+			logger.Error(err)
+		}
+	}
+
+	if gc.LockFileMaxAge != "" {
+		LockFileMaxAge, err = time.ParseDuration(gc.LockFileMaxAge)
 		if err != nil {
 			logger.Error(err)
 		}

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -16,7 +16,7 @@ func TestInitialize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating conf file: %v", err)
 	}
-	content := []byte("archs: [noarch, x86_64, arm64]\ncachelife: 10m\nallowunsafeurl: true")
+	content := []byte("archs: [noarch, x86_64, arm64]\ncachelife: 10m\nlockfilemaxage: 1h\nallowunsafeurl: true")
 	if _, err := f.Write(content); err != nil {
 		t.Fatalf("error writing conf file: %v", err)
 	}
@@ -37,6 +37,10 @@ func TestInitialize(t *testing.T) {
 
 	if got, want := settings.CacheLife, 10*time.Minute; got != want {
 		t.Errorf("settings.CacheLife got: %v, want: %v", got, want)
+	}
+
+	if got, want := settings.LockFileMaxAge, 1*time.Hour; got != want {
+		t.Errorf("settings.LockfileMaxAge got: %v, want: %v", got, want)
 	}
 
 	if got, want := settings.AllowUnsafeURL, true; got != want {

--- a/system/system.go
+++ b/system/system.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/google/googet/v2/goolib"
@@ -46,12 +48,91 @@ func Verify(dir string, ps *goolib.PkgSpec) error {
 	return goolib.Exec(filepath.Join(dir, v.Path), v.Args, v.ExitCodes, out)
 }
 
-// ObtainLock obtains a lock on a file path.
-func ObtainLock(lockFile string) (func(), error) {
-	err := os.MkdirAll(filepath.Dir(lockFile), 0755)
+// isLockFileStale checks if the lock file is older than maxAge.
+// It returns false if the file does not exist.
+func isLockFileStale(lockFile string, maxAge time.Duration) (bool, error) {
+	fi, err := os.Stat(lockFile)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return time.Since(fi.ModTime()) > maxAge, nil
+}
+
+// readPID reads the PID from the lock file.
+func readPID(lockFile string) (int, error) {
+	data, err := os.ReadFile(lockFile)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(string(data))
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse PID from lockfile: %v", err)
+	}
+	return pid, nil
+}
+
+// killProcess kills the process with the given PID.
+func killProcess(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return p.Signal(syscall.SIGKILL)
+}
+
+// handleStaleLock checks for stale lock files. If the lock file is not stale or
+// we can't read a valid PID from the lock file, then do nothing. If the PID in
+// the lock file represents a still-running GooGet process, then kill the
+// running GooGet. Remove the stale lock file in any case.
+func handleStaleLock(lockFile string, maxAge time.Duration) {
+	if stale, err := isLockFileStale(lockFile, maxAge); err != nil {
+		logger.Errorf("Failed to check lock file staleness: %v", err)
+		return
+	} else if !stale {
+		return
+	}
+
+	pid, err := readPID(lockFile)
+	if err != nil {
+		logger.Errorf("Failed to read PID from lock file: %v", err)
+		return
+	}
+
+	if running, err := isGooGetRunning(pid); err != nil {
+		logger.Errorf("Failed to check if PID %d is running: %v", pid, err)
+	} else if running {
+		fmt.Printf("GooGet lock held by stale process with PID %d, attempting to kill.\n", pid)
+		if err := killProcess(pid); err != nil {
+			fmt.Printf("Failed to kill process %d: %v\n", pid, err)
+			return
+		}
+		fmt.Printf("Killed stale process with PID %d.\n", pid)
+	}
+
+	fmt.Println("Removing stale lock file.")
+	var removeErr error
+	// Retry removal since the OS might take a moment to release the file handle
+	// after the process is killed.
+	for i := 0; i < 5; i++ {
+		removeErr = os.Remove(lockFile)
+		if removeErr == nil || os.IsNotExist(removeErr) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	logger.Errorf("Failed to remove stale lock file: %v", removeErr)
+}
+
+// ObtainLock attempts to obtain an exclusive lock on the provided file.
+func ObtainLock(lockFile string, maxAge time.Duration) (func(), error) {
+	if err := os.MkdirAll(filepath.Dir(lockFile), 0755); err != nil {
 		return nil, err
 	}
+
+	handleStaleLock(lockFile, maxAge)
 
 	f, err := os.OpenFile(lockFile, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
@@ -66,17 +147,21 @@ func ObtainLock(lockFile string) (func(), error) {
 	}()
 
 	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
 	// 90% of all GooGet runs happen in < 60s, we wait 70s.
-	for i := 1; i < 15; i++ {
+	timeout := time.After(70 * time.Second)
+
+	for {
 		select {
 		case err := <-c:
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to obtain lock: %v", err)
 			}
 			return cleanup, nil
 		case <-ticker.C:
-			fmt.Fprintln(os.Stdout, "GooGet lock already held, waiting...")
+			fmt.Println("GooGet lock already held, waiting...")
+		case <-timeout:
+			return nil, errors.New("timed out waiting for lock after 70 seconds")
 		}
 	}
-	return nil, errors.New("timed out waiting for lock")
 }

--- a/system/system_test.go
+++ b/system/system_test.go
@@ -5,13 +5,17 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 )
 
+// TestObtainLock verifies the basic functionality of ObtainLock, ensuring it
+// creates a lock file and that the cleanup function removes it.
 func TestObtainLock(t *testing.T) {
-	tempDir := t.TempDir()
-	lockFile := filepath.Join(tempDir, "googet.lock")
-	cleanup, err := ObtainLock(lockFile)
+	lockFile := filepath.Join(t.TempDir(), "googet.lock")
+	cleanup, err := ObtainLock(lockFile, 0)
 	if err != nil {
 		t.Fatalf("ObtainLock: %v", err)
 	}
@@ -24,5 +28,112 @@ func TestObtainLock(t *testing.T) {
 	cleanup()
 	if _, err := os.Stat(lockFile); !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("os.Stat(%v): lockfile still exists after cleanup", lockFile)
+	}
+}
+
+// TestObtainLock_StaleLock ensures that ObtainLock can successfully acquire a
+// lock even if a stale lock file exists.
+func TestObtainLock_StaleLock(t *testing.T) {
+	lockFile := filepath.Join(t.TempDir(), "googet.lock")
+	// Create an initial lock file. We write the PID of the current process, but
+	// close the file handle so there's no actual lock held. This simulates a
+	// stale lock from a dead process.
+	if err := os.WriteFile(lockFile, []byte(strconv.Itoa(os.Getpid())), 0600); err != nil {
+		t.Fatalf("os.WriteFile: %v", err)
+	}
+
+	// Make the lock file appear stale.
+	staleTime := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(lockFile, staleTime, staleTime); err != nil {
+		t.Fatalf("os.Chtimes: %v", err)
+	}
+
+	// Now, try to obtain the lock again. It should succeed because the existing
+	// lock is stale. Note that the PID of the test process is written into the
+	// lockfile, but it isn't killed because the name does not match googet.
+	cleanup, err := ObtainLock(lockFile, 1*time.Hour)
+	if err != nil {
+		t.Fatalf("ObtainLock with stale lock: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatalf("ObtainLock got nil cleanup, want non-nil")
+	}
+
+	fi, err := os.Stat(lockFile)
+	if err != nil {
+		t.Fatalf("os.Stat after obtaining lock: %v", err)
+	}
+	if age := time.Since(fi.ModTime()); age > 1*time.Minute {
+		t.Errorf("lock file age is %v, want < 1 minute; stale file was likely not removed and re-created", age)
+	}
+
+	cleanup()
+	if _, err := os.Stat(lockFile); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("os.Stat(%v): lockfile still exists after cleanup", lockFile)
+	}
+}
+
+// TestObtainLock_PID verifies that ObtainLock writes the correct process ID
+// into the lock file.
+func TestObtainLock_PID(t *testing.T) {
+	lockFile := filepath.Join(t.TempDir(), "googet.lock")
+	cleanup, err := ObtainLock(lockFile, 0)
+	if err != nil {
+		t.Fatalf("ObtainLock: %v", err)
+	}
+	defer cleanup()
+	content, err := os.ReadFile(lockFile)
+	if err != nil {
+		t.Fatalf("os.ReadFile: %v", err)
+	}
+	pidStr := strings.TrimSpace(string(content))
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		t.Fatalf("strconv.Atoi(%q): %v", pidStr, err)
+	}
+	if got, want := pid, os.Getpid(); got != want {
+		t.Errorf("lockfile pid got %d, want %d", got, want)
+	}
+}
+
+// TestObtainLock_Locked ensures that once a lock is obtained, subsequent calls
+// to ObtainLock will block until the lock is released.
+func TestObtainLock_Locked(t *testing.T) {
+	lockFile := filepath.Join(t.TempDir(), "googet.lock")
+	cleanup1, err := ObtainLock(lockFile, 0)
+	if err != nil {
+		t.Fatalf("ObtainLock: %v", err)
+	}
+
+	type obtainLockResult struct {
+		cleanup func()
+		err     error
+	}
+	resultCh := make(chan obtainLockResult)
+	go func() {
+		cleanup2, err := ObtainLock(lockFile, 1*time.Hour)
+		resultCh <- obtainLockResult{cleanup2, err}
+	}()
+
+	select {
+	case res := <-resultCh:
+		t.Fatalf("ObtainLock should have blocked, but returned immediately with result: %+v", res)
+	case <-time.After(1 * time.Second):
+		// It's blocking as expected.
+	}
+
+	cleanup1()
+
+	select {
+	case res := <-resultCh:
+		if res.err != nil {
+			t.Fatalf("Second ObtainLock failed with: %v", res.err)
+		}
+		if res.cleanup == nil {
+			t.Fatal("Second ObtainLock returned nil cleanup")
+		}
+		res.cleanup() // Clean up the second lock.
+	case <-time.After(1 * time.Second): // Should be quick to get the lock now.
+		t.Fatal("Second ObtainLock timed out after releasing first lock")
 	}
 }


### PR DESCRIPTION
* Write process id in the lockfile when we create it.
* If the lockfile is older than settings.LockFileMaxAge (default: 24 hours), try to kill the owning googet process.

In order to be able to read the PID from the lockfile, we slightly alter the lock management. On Linux, we first obtain an exclusive lock, then downgrade to a shared lock which allows other processes to open the file for reading. On Windows, we only lock a high byte offset of the lock file. Other process can read the PID from the lower bytes of the file, but cannot obtain an exclusive lock.