### PR TITLE
Exit immediately when reading a repo fails

### DIFF
--- a/cli/available/available.go
+++ b/cli/available/available.go
@@ -86,7 +86,11 @@ func (cmd *availableCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...inte
 	}
 
 	m := make(map[string][]string)
-	rm := downloader.AvailableVersions(ctx, repos, settings.CacheDir(), settings.CacheLife)
+	rm, err := downloader.AvailableVersions(ctx, repos, settings.CacheDir(), settings.CacheLife)
+	if err != nil {
+		logger.Errorf("Failed to download repos: %v", err)
+		return subcommands.ExitFailure
+	}
 	for u, r := range rm {
 		for _, p := range r.Packages {
 			m[u] = append(m[u], p.PackageSpec.Name+"."+p.PackageSpec.Arch+"."+p.PackageSpec.Version)

--- a/cli/check/check.go
+++ b/cli/check/check.go
@@ -81,7 +81,11 @@ func (cmd *checkCmd) Execute(ctx context.Context, f *flag.FlagSet, _ ...interfac
 		return subcommands.ExitFailure
 	}
 
-	rm := downloader.AvailableVersions(ctx, repos, cache, settings.CacheLife)
+	rm, err := downloader.AvailableVersions(ctx, repos, cache, settings.CacheLife)
+	if err != nil {
+		logger.Errorf("Failed to download repos: %v", err)
+		return subcommands.ExitFailure
+	}
 	unmanaged := make(map[string]string)
 	installed := make(map[string]struct{})
 	for _, ps := range state {

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -70,7 +70,11 @@ func (cmd *downloadCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...i
 		return subcommands.ExitFailure
 	}
 
-	rm := downloader.AvailableVersions(ctx, repos, settings.CacheDir(), settings.CacheLife)
+	rm, err := downloader.AvailableVersions(ctx, repos, settings.CacheDir(), settings.CacheLife)
+	if err != nil {
+		logger.Errorf("Failed to download repos: %v", err)
+		return subcommands.ExitFailure
+	}
 	exitCode := subcommands.ExitSuccess
 
 	dir := cmd.downloadDir

--- a/cli/install/install.go
+++ b/cli/install/install.go
@@ -102,7 +102,10 @@ func (cmd *installCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...an
 			logger.Error("No repos defined, create a .repo file or pass using the -sources flag.")
 			return subcommands.ExitFailure
 		}
-		i.repoMap = i.downloader.AvailableVersions(ctx, repos, i.cache, settings.CacheLife)
+		if i.repoMap, err = i.downloader.AvailableVersions(ctx, repos, i.cache, settings.CacheLife); err != nil {
+			logger.Errorf("Failed to download repos: %v", err)
+			return subcommands.ExitFailure
+		}
 	}
 
 	var errs error

--- a/cli/latest/latest.go
+++ b/cli/latest/latest.go
@@ -87,7 +87,11 @@ func (cmd *latestCmd) Execute(ctx context.Context, flags *flag.FlagSet, _ ...int
 		return subcommands.ExitFailure
 	}
 
-	rm := downloader.AvailableVersions(ctx, repos, settings.CacheDir(), settings.CacheLife)
+	rm, err := downloader.AvailableVersions(ctx, repos, settings.CacheDir(), settings.CacheLife)
+	if err != nil {
+		logger.Errorf("Failed to download repos: %v", err)
+		return subcommands.ExitFailure
+	}
 	v, _, a, err := client.FindRepoLatest(pi, rm, settings.Archs)
 	if err != nil {
 		logger.Errorf("Failed to find package: %v", err)

--- a/cli/update/update.go
+++ b/cli/update/update.go
@@ -87,7 +87,11 @@ func (cmd *updateCmd) Execute(ctx context.Context, _ *flag.FlagSet, _ ...interfa
 		return subcommands.ExitFailure
 	}
 
-	rm := downloader.AvailableVersions(ctx, repos, cache, settings.CacheLife)
+	rm, err := downloader.AvailableVersions(ctx, repos, cache, settings.CacheLife)
+	if err != nil {
+		logger.Errorf("Failed to download repos: %v", err)
+		return subcommands.ExitFailure
+	}
 	ud := updates(state.PackageMap(), rm)
 	if ud == nil {
 		fmt.Println("No updates available for any installed packages.")

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/text v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
A package information must be retrieved from all the repos to determine priorities and figure out right installation candidate avoiding package overrides from unintended repos.